### PR TITLE
chore: align cli baseline to 2.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.0.0 (2026-03-02)
+## 2.8.7 (2026-03-02)
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "noetl"
-version = "1.0.0"
+version = "2.8.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl"
-version = "1.0.0"
+version = "2.8.7"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"


### PR DESCRIPTION
Resets CLI repository baseline to match the already-published crate line (`noetl` v2.8.7), while keeping `noetl` and `ntl` interchangeable binaries.

Changes:
- Cargo.toml version -> 2.8.7
- Cargo.lock package version -> 2.8.7
- CHANGELOG top version heading -> 2.8.7
