### PR TITLE
chore(cli): remove legacy package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ The `noetl` binary is built into the Docker image using a multi-stage build:
 # Rust builder stage compiles the CLI
 FROM rust:1.75-slim as rust-builder
 WORKDIR /build
-COPY noetlctl/ ./
+COPY cli/ ./
 RUN cargo build --release
 
 # Production stage includes the binary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "noetlctl"
+name = "noetl"
 version = "2.5.11"
 description = "NoETL CLI (Rust) - Command-line interface for NoETL workflow automation"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- rename stale pyproject metadata from the retired command name to noetl
- update README Docker snippet to use the current cli source directory name

## Validation
- cargo metadata --no-deps --format-version 1
- git diff --check