### PR TITLE
chore(workspace): add noetl-executor crate skeleton (R-1.1 PR-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1569,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "noetl-executor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
+[workspace]
+# Cargo workspace.  The CLI binary remains the root package; `executor`
+# is a workspace member crate that hosts the shared execution core
+# (LocalPlaybookSource for the CLI's `noetl run --runtime local` path
+# and NatsCommandSource for noetl-worker — see Appendix H of the
+# global hybrid cloud blueprint, https://noetl.dev/docs/architecture/
+# noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint).
+members = ["executor"]
+
 [package]
 name = "noetl"
 version = "2.17.1"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "noetl-executor"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/noetl/cli"
+description = "NoETL shared execution core - drives playbook commands from local YAML or NATS"
+publish = false
+
+[dependencies]
+# Async runtime; matches the CLI's tokio surface so the shared crate
+# can run inside either the CLI or the worker binary.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+async-trait = "0.1"
+
+# Serialization for command + event envelopes.
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+
+# Error handling.
+anyhow = "1.0"
+thiserror = "1.0"
+
+# Time + UUID for event ids and timestamps.
+chrono = { version = "0.4", features = ["serde"] }
+
+# Tracing.
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/executor/src/dispatch.rs
+++ b/executor/src/dispatch.rs
@@ -1,0 +1,46 @@
+//! Tool dispatch — routes a [`crate::source::Command`] to the tool
+//! kind that should execute it.
+//!
+//! Skeleton.  R-1.2 wires this to the `noetl-tools` registry so the
+//! same code that the CLI uses today (via `playbook_runner.rs`'s
+//! tool dispatch) services every executor consumer.
+
+use anyhow::Result;
+
+use crate::runtime::ExecutionContext;
+use crate::source::Command;
+
+/// Result of running one command.  R-1.2 will replace the
+/// `serde_json::Value` payload with the concrete tool-result envelope
+/// that the Python `noetl.runtime.events.report_event` builds (status,
+/// duration, error, output, render context updates).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CommandOutcome {
+    pub command_id: String,
+    pub status: CommandStatus,
+    pub output: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CommandStatus {
+    Completed,
+    Failed,
+}
+
+/// Dispatches one command through the tool registry.
+///
+/// R-1.1 skeleton: always returns a `Completed` outcome with an empty
+/// payload so downstream wiring can be exercised end-to-end without a
+/// real tool surface.  R-1.2 replaces the body with the real
+/// `noetl-tools` registry dispatch.
+pub async fn dispatch_command(
+    _ctx: &ExecutionContext,
+    cmd: Command,
+) -> Result<CommandOutcome> {
+    Ok(CommandOutcome {
+        command_id: cmd.command_id,
+        status: CommandStatus::Completed,
+        output: serde_json::json!({}),
+    })
+}

--- a/executor/src/events.rs
+++ b/executor/src/events.rs
@@ -1,0 +1,108 @@
+//! Event emission — pluggable sink that captures the events the
+//! executor produces during one execution.
+//!
+//! Both CLI and worker emit the same shape; only the sink differs:
+//!
+//! - CLI: `StdoutEventSink` — pretty-prints events to the terminal
+//!   (R-1.2 will introduce this).
+//! - Worker: `NatsEventSink` — publishes to the configured NATS
+//!   subject (R-1.3 will introduce this).
+//!
+//! The envelope shape mirrors the Python-side
+//! `noetl.runtime.events.report_event` payload so wire-format
+//! compatibility holds across stacks.  See the noetl/noetl wiki page
+//! `handle_event_timing` for the field catalogue.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// One event the executor emits.  Keep field naming aligned with the
+/// Python side (`noetl.event` table columns) so envelopes can be
+/// projected by either stack.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExecutorEvent {
+    pub execution_id: String,
+    pub event_type: String,
+    /// Step name (`node_id` / `node_name` in the Python projector).
+    pub step: String,
+    pub status: String,
+    /// Wall-clock when the event was produced.
+    pub created_at: DateTime<Utc>,
+    /// Free-form payload; the projector reads typed fields out of this.
+    pub context: serde_json::Value,
+}
+
+#[async_trait]
+pub trait EventSink: Send + Sync {
+    /// Emit `event` to whatever durable surface the sink is bound to.
+    /// Implementations should be idempotent per `event_id` once R-1.2
+    /// adds id assignment.
+    async fn emit(&self, event: ExecutorEvent) -> Result<()>;
+}
+
+/// Trait alias used by the dispatch loop — wraps a sink and a
+/// pre-computed `execution_id` so callers don't have to thread it
+/// through every call site.
+pub struct EventEmitter {
+    pub sink: std::sync::Arc<dyn EventSink>,
+    pub execution_id: String,
+}
+
+impl EventEmitter {
+    pub fn new(execution_id: String, sink: std::sync::Arc<dyn EventSink>) -> Self {
+        Self { sink, execution_id }
+    }
+
+    pub async fn emit(
+        &self,
+        event_type: &str,
+        step: &str,
+        status: &str,
+        context: serde_json::Value,
+    ) -> Result<()> {
+        let event = ExecutorEvent {
+            execution_id: self.execution_id.clone(),
+            event_type: event_type.to_string(),
+            step: step.to_string(),
+            status: status.to_string(),
+            created_at: Utc::now(),
+            context,
+        };
+        self.sink.emit(event).await
+    }
+}
+
+/// Drops every event on the floor.  Useful in tests and as the default
+/// during the R-1.1 skeleton phase before the real CLI/worker sinks
+/// exist.
+#[derive(Default)]
+pub struct NoopSink;
+
+#[async_trait]
+impl EventSink for NoopSink {
+    async fn emit(&self, _event: ExecutorEvent) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn noop_sink_accepts_any_event() {
+        let sink: Arc<dyn EventSink> = Arc::new(NoopSink);
+        let emitter = EventEmitter::new("exec_test".into(), sink);
+        emitter
+            .emit(
+                "batch.completed",
+                "start",
+                "COMPLETED",
+                serde_json::json!({"processing_ms": 12.3}),
+            )
+            .await
+            .expect("noop emit");
+    }
+}

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -1,0 +1,40 @@
+//! # `noetl-executor` — shared execution core
+//!
+//! Hosts the execution logic that the NoETL CLI's `noetl run --runtime
+//! local` path and the `noetl-worker` NATS daemon share.  See Appendix
+//! H of the global hybrid cloud blueprint at
+//! <https://noetl.dev/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint>
+//! for the architectural rationale.
+//!
+//! ## Shape
+//!
+//! ```text
+//!   CommandSource  ->  dispatch::route  ->  ToolRegistry  ->  EventSink
+//!   (LocalPlaybook                                            (CLI stdout or
+//!    or NATS)                                                  worker NATS)
+//! ```
+//!
+//! Both surfaces (`noetl run --runtime local` and `noetl-worker`) plug
+//! a different [`source::CommandSource`] and a different
+//! [`events::EventSink`] into the same [`runtime::ExecutionContext`].
+//!
+//! ## Stability
+//!
+//! `0.1.x` is a pre-production skeleton.  Public API is expected to
+//! churn through phases R-1.1 (this skeleton) and R-1.2 (CLI wires
+//! into it).  Treat the crate as internal until it ships in
+//! `noetl-worker` (R-1.3).
+
+#![allow(dead_code)]
+
+pub mod runtime;
+pub mod source;
+pub mod sources;
+pub mod dispatch;
+pub mod events;
+
+/// Re-exports for downstream crates (the CLI and the worker) so they
+/// can import via the crate root.
+pub use events::{EventEmitter, EventSink};
+pub use runtime::{CredentialResolver, ExecutionContext};
+pub use source::{Command, CommandSource};

--- a/executor/src/runtime.rs
+++ b/executor/src/runtime.rs
@@ -1,0 +1,63 @@
+//! Per-execution runtime context shared between sources, dispatch, and
+//! event emission.
+//!
+//! `ExecutionContext` is the durable carrier for one playbook execution.
+//! Both the CLI's local-mode runner and the worker's NATS daemon
+//! construct one of these per invocation; the dispatch layer reads from
+//! it to resolve credentials, look up rendered step input, and emit
+//! events into the configured sink.
+//!
+//! This module deliberately starts minimal — the skeleton commits the
+//! shape, R-1.2 (extraction PR) fills in the concrete fields by porting
+//! them from `repos/cli/src/playbook_runner.rs`.
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Identifies one playbook execution end-to-end.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExecutionId(pub String);
+
+/// Trait for resolving keychain credential aliases at step-execution
+/// time.  Mirrors the Python-side `noetl.core.credential_refs`
+/// resolution flow; see noetl/noetl wiki page `credential-resolution-flow`.
+#[async_trait::async_trait]
+pub trait CredentialResolver: Send + Sync {
+    /// Resolve `alias` (e.g. `"duffel"`) to its concrete credential
+    /// envelope.  Implementations consult the NoETL keychain (worker
+    /// path) or the CLI's local keychain cache (CLI path).
+    async fn resolve(&self, alias: &str) -> Result<serde_json::Value>;
+}
+
+/// Carries everything one execution needs.  Cheap to clone via `Arc`s
+/// on the inner heavy fields.
+#[derive(Clone)]
+pub struct ExecutionContext {
+    pub execution_id: ExecutionId,
+    pub credentials: Arc<dyn CredentialResolver>,
+    /// Step-level results accumulated during execution.  Used by the
+    /// template layer to render `{{ step_name.result }}` references.
+    pub step_results: Arc<tokio::sync::RwLock<HashMap<String, serde_json::Value>>>,
+    /// Workload payload (`workload:` block from the YAML, plus any
+    /// `--set` overrides from the CLI or runtime defaults from NATS).
+    pub workload: Arc<serde_json::Value>,
+}
+
+impl ExecutionContext {
+    /// Construct a fresh context.  R-1.2 will add a builder that
+    /// reads the workload from the YAML's `workload:` block and
+    /// applies CLI overrides.
+    pub fn new(
+        execution_id: ExecutionId,
+        credentials: Arc<dyn CredentialResolver>,
+        workload: serde_json::Value,
+    ) -> Self {
+        Self {
+            execution_id,
+            credentials,
+            step_results: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            workload: Arc::new(workload),
+        }
+    }
+}

--- a/executor/src/source.rs
+++ b/executor/src/source.rs
@@ -1,0 +1,52 @@
+//! `CommandSource` — abstraction over how the executor receives the
+//! next command to run.
+//!
+//! The CLI's local mode parses YAML into a graph of commands and
+//! supplies them via [`crate::sources::local_playbook::LocalPlaybookSource`].
+//! The worker (R-1.3) implements a NATS-backed source that pulls from
+//! a durable consumer.  The executor never cares which one it has.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// One command the executor will dispatch to a tool.
+///
+/// The shape mirrors the Python-side `noetl.command` row + envelope as
+/// of v2.103.x — keep the field names aligned so wire-format
+/// compatibility is automatic.  R-1.2 will add the remaining fields
+/// (step, tool kind, input, render context, etc.) by porting the YAML
+/// command builder from `repos/cli/src/playbook_runner.rs`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Command {
+    /// Stable identifier for this command.  CLI generates a UUID;
+    /// the worker uses the snowflake id from `noetl.command`.
+    pub command_id: String,
+
+    /// Execution this command belongs to.
+    pub execution_id: String,
+
+    /// Step name from the playbook (e.g. `"fetch_calendar"`).
+    pub step: String,
+
+    /// Tool kind that dispatch will route to (e.g. `"http"`, `"postgres"`).
+    pub tool_kind: String,
+
+    /// Tool-specific input payload, already rendered against the merged
+    /// step context.
+    pub input: serde_json::Value,
+}
+
+/// Pull-model command source.
+///
+/// `next()` returns:
+/// - `Ok(Some(cmd))` — one command to dispatch.
+/// - `Ok(None)` — the source is exhausted (local-mode playbook
+///   complete) and the executor should drain its outstanding work and
+///   exit.  Long-running sources (worker NATS) never return `None` in
+///   normal operation.
+/// - `Err(e)` — transient or terminal source error; the caller's retry
+///   policy decides whether to call `next()` again.
+#[async_trait]
+pub trait CommandSource: Send + Sync {
+    async fn next(&mut self) -> Result<Option<Command>>;
+}

--- a/executor/src/sources/local_playbook.rs
+++ b/executor/src/sources/local_playbook.rs
@@ -1,0 +1,78 @@
+//! Local-playbook command source.
+//!
+//! Skeleton.  R-1.2 extracts the actual playbook-parsing + command-
+//! generation logic from `repos/cli/src/playbook_runner.rs` (~2,700
+//! LoC) into this module and reduces the CLI to a thin orchestration
+//! layer around the executor.
+//!
+//! For now the type is a placeholder that satisfies the trait without
+//! reading any YAML — wiring R-1.2 lifts the real implementation
+//! verbatim.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::VecDeque;
+
+use crate::source::{Command, CommandSource};
+
+/// Reads commands from an in-memory queue.  R-1.2 will replace this
+/// with the real YAML parser + command builder lifted from
+/// `repos/cli/src/playbook_runner.rs`.
+pub struct LocalPlaybookSource {
+    pending: VecDeque<Command>,
+}
+
+impl LocalPlaybookSource {
+    /// Constructs a source from a pre-built command queue.  Useful for
+    /// tests and as the temporary shape during the R-1.1 skeleton —
+    /// the CLI doesn't depend on this crate yet so no real playbook
+    /// path is needed.
+    pub fn from_queue(commands: Vec<Command>) -> Self {
+        Self {
+            pending: commands.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl CommandSource for LocalPlaybookSource {
+    async fn next(&mut self) -> Result<Option<Command>> {
+        Ok(self.pending.pop_front())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cmd(step: &str, kind: &str) -> Command {
+        Command {
+            command_id: format!("cmd_{step}"),
+            execution_id: "exec_test".into(),
+            step: step.into(),
+            tool_kind: kind.into(),
+            input: json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_commands_in_order_then_none() {
+        let mut src = LocalPlaybookSource::from_queue(vec![
+            cmd("a", "http"),
+            cmd("b", "postgres"),
+        ]);
+
+        let first = src.next().await.unwrap().expect("a");
+        assert_eq!(first.step, "a");
+        let second = src.next().await.unwrap().expect("b");
+        assert_eq!(second.step, "b");
+        assert!(src.next().await.unwrap().is_none(), "drained");
+    }
+
+    #[tokio::test]
+    async fn empty_queue_is_immediately_drained() {
+        let mut src = LocalPlaybookSource::from_queue(vec![]);
+        assert!(src.next().await.unwrap().is_none());
+    }
+}

--- a/executor/src/sources/mod.rs
+++ b/executor/src/sources/mod.rs
@@ -1,0 +1,8 @@
+//! Concrete [`crate::source::CommandSource`] implementations.
+//!
+//! - [`local_playbook`] parses a YAML playbook and emits commands
+//!   inline.  Used by the CLI's `noetl run --runtime local`.
+//! - A `nats` module will land in R-1.3 when the worker depends on
+//!   this crate.
+
+pub mod local_playbook;


### PR DESCRIPTION
## Summary

First of two PRs that complete R-1.1 of the Rust migration roadmap ([Appendix H of the global hybrid cloud blueprint, noetl/docs#174](https://github.com/noetl/docs/pull/174)).  This PR ships the **skeleton only** — no CLI behavior change.  The second PR (R-1.2, tracked at [noetl/cli#19](https://github.com/noetl/cli/issues/19)) lifts the actual playbook-parsing + command-generation logic from \`src/playbook_runner.rs\` into the new crate and wires the CLI to depend on it.

## Why a shared executor crate

\`repos/cli/src/playbook_runner.rs\` and \`repos/worker\` are roughly 95% the same execution logic with different command sources (local YAML vs NATS pull).  Appendix H of the blueprint identifies extracting this into a shared \`noetl-executor\` crate as the highest-leverage early step of the Rust migration.  Both \`repos/cli\` and \`repos/worker\` end up depending on it; the CLI gets full distributed-runtime semantics in local mode for free, and the worker gets the CLI's ergonomic single-binary debug surface.

## What this PR adds

\`\`\`
repos/cli/
  Cargo.toml             <- new [workspace] section, members = ["executor"]
  executor/
    Cargo.toml           <- noetl-executor 0.1.0, private (publish = false)
    src/
      lib.rs             <- module surface + re-exports
      runtime.rs         <- ExecutionContext, ExecutionId, CredentialResolver trait
      source.rs          <- Command struct + CommandSource trait
      sources/
        mod.rs
        local_playbook.rs   <- placeholder queue-backed LocalPlaybookSource
      dispatch.rs        <- CommandOutcome / CommandStatus + dispatch_command stub
      events.rs          <- ExecutorEvent + EventSink trait + NoopSink + EventEmitter
\`\`\`

### Naming choices

- Field names on \`Command\` align with the Python-side \`noetl.command\` row.
- \`ExecutorEvent\` shape mirrors the Python-side \`noetl.runtime.events.report_event\` payload (\`execution_id\`, \`event_type\`, \`node_id\`/\`step\`, \`status\`, \`created_at\`, \`context\` JSONB).
- Wire-format compatibility with the existing Python stack is automatic.

### Why workspace, not separate repo

Per Appendix H § H.8: workspace-inside-\`repos/cli\` is the fastest path to bootstrap.  Promotion to a standalone \`noetl/executor\` repo happens when \`noetl-worker\` depends on it (R-1.3).  Until then \`publish = false\` to discourage external dependency.

## What does NOT change

- No CLI binary behavior change.  \`noetl\` and \`ntl\` binaries are identical to v2.17.1.
- No public API change.
- No new runtime dependency.

## Tests

3 new unit tests in \`noetl-executor\`:

- \`sources::local_playbook::tests::returns_commands_in_order_then_none\`
- \`sources::local_playbook::tests::empty_queue_is_immediately_drained\`
- \`events::tests::noop_sink_accepts_any_event\`

All pass:

\`\`\`
$ cargo test -p noetl-executor
running 3 tests
test sources::local_playbook::tests::empty_queue_is_immediately_drained ... ok
test events::tests::noop_sink_accepts_any_event ... ok
test sources::local_playbook::tests::returns_commands_in_order_then_none ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

\`cargo check --workspace\` green:

\`\`\`
Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 2m 33s
\`\`\`

Only pre-existing CLI dead-code warnings; no new ones from this PR.

## Next: R-1.2

Will:
1. Lift the playbook-parsing + command-generation logic from \`src/playbook_runner.rs\` (~2,700 LoC) into \`executor/src/sources/local_playbook.rs\`.
2. Wire \`dispatch::dispatch_command\` to the \`noetl-tools\` registry.
3. Replace the inline runner in \`main.rs\` with a call into \`noetl-executor\`.
4. Verify CLI integration tests pass unchanged.

Refs noetl/cli#19 (partial — second PR closes it)
Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)