### PR TITLE
feat(executor): wire Tool::Shell through noetl-tools bridge (R-1.1 PR-2c-4)

### DIFF
--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -45,7 +45,7 @@ use anyhow::Result;
 use noetl_tools::context::ExecutionContext as ToolsExecutionContext;
 use noetl_tools::registry::{Tool as ToolsRegistryTool, ToolConfig};
 use noetl_tools::result::{ToolResult, ToolStatus};
-use noetl_tools::tools::RhaiTool;
+use noetl_tools::tools::{RhaiTool, ShellTool};
 
 use crate::playbook::{CmdsList, Tool};
 
@@ -218,12 +218,30 @@ pub fn to_tools_context_for_rhai(bridge: &BridgeContext) -> ToolsExecutionContex
 /// current behaviour of emitting an error.
 pub fn to_tools_config(tool: &Tool) -> ToolConfig {
     let (kind, config) = match tool {
-        Tool::Shell { cmds } => (
-            "shell",
-            serde_json::json!({
-                "cmds": cmds_to_value(cmds),
-            }),
-        ),
+        Tool::Shell { cmds } => {
+            // noetl-tools::ShellConfig expects a single `command`
+            // string.  CLI's CmdsList::Multiple becomes a newline-
+            // joined block (one bash invocation with a multi-line
+            // script); CmdsList::Single becomes the string verbatim.
+            //
+            // Important: this is the per-call ToolConfig shape.  The
+            // Tool::Shell arm of `dispatch_via_registry` does NOT use
+            // this helper because the CLI's runtime semantics require
+            // one bash invocation PER command (independent process,
+            // no shared cwd/env state) — the dispatch arm loops and
+            // builds per-command ToolConfigs via [`shell_command_config`].
+            (
+                "shell",
+                serde_json::json!({
+                    "command": match cmds {
+                        CmdsList::Single(s) => s.clone(),
+                        CmdsList::Multiple(v) => v.join("\n"),
+                    },
+                    "shell": "bash",
+                    "capture": true,
+                }),
+            )
+        }
         Tool::Http {
             method,
             url,
@@ -291,12 +309,21 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
     }
 }
 
-fn cmds_to_value(cmds: &CmdsList) -> serde_json::Value {
-    match cmds {
-        CmdsList::Single(s) => serde_json::Value::String(s.clone()),
-        CmdsList::Multiple(v) => {
-            serde_json::Value::Array(v.iter().map(|s| serde_json::Value::String(s.clone())).collect())
-        }
+/// Build a single-command ToolConfig for the shell tool.  Used by
+/// the `Tool::Shell` dispatch arm to preserve the CLI's per-command
+/// bash-invocation semantics (independent process, no shared
+/// cwd/env state across commands).
+fn shell_command_config(command: &str) -> ToolConfig {
+    ToolConfig {
+        kind: "shell".to_string(),
+        config: serde_json::json!({
+            "command": command,
+            "shell": "bash",
+            "capture": true,
+        }),
+        timeout: None,
+        retry: None,
+        auth: None,
     }
 }
 
@@ -385,9 +412,73 @@ pub async fn dispatch_via_registry(
                 .map_err(|e| anyhow::anyhow!("rhai dispatch failed: {}", e))?;
             from_tools_result(result)
         }
-        Tool::Shell { .. } => {
-            // PR-2c-4 fills this in.
-            Ok(BridgeOutcome::empty())
+        Tool::Shell { cmds } => {
+            // PR-2c-4: dispatch through noetl_tools::ShellTool.
+            //
+            // CLI semantics preserved:
+            // - CmdsList::Single splits on newlines into individual
+            //   commands; each runs in its own bash invocation.
+            // - CmdsList::Multiple runs each element in its own
+            //   bash invocation in order.
+            // - Bails on first non-zero exit (CLI's existing
+            //   `anyhow::bail!("Command failed ...")`).
+            // - Returns the last command's stdout as the step result.
+            //
+            // Note vs CLI: noetl-tools' ShellTool collects stdout +
+            // stderr and returns them in the ToolResult at the end
+            // of execution.  The CLI's inline implementation
+            // streamed output to the terminal line-by-line as the
+            // command ran.  For long-running shell steps users no
+            // longer see real-time output.  Documented in the PR
+            // body and on the executor-crate-architecture wiki
+            // page's semantic-divergence table.
+            let commands: Vec<String> = match cmds {
+                CmdsList::Single(cmd) => cmd
+                    .lines()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect(),
+                CmdsList::Multiple(c) => c.clone(),
+            };
+
+            let shell_tool = ShellTool::new();
+            let ctx = to_tools_context(bridge);
+            let mut last_outcome = BridgeOutcome::empty();
+            for command in commands {
+                let config = shell_command_config(&command);
+                let result = shell_tool
+                    .execute(&config, &ctx)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("shell dispatch failed: {}", e))?;
+
+                // noetl-tools' shell tool packs the result into
+                // ToolResult.data as a typed JSON object:
+                //   {"exit_code": i32, "stdout": String, "stderr": String}
+                // For the CLI's step-result contract (a single
+                // string = the command's stdout), we unwrap stdout
+                // directly here.  `from_tools_result` would
+                // otherwise stringify the whole JSON dict.
+                if result.status != ToolStatus::Success {
+                    let exit_code = result
+                        .data
+                        .as_ref()
+                        .and_then(|d| d.get("exit_code"))
+                        .and_then(|v| v.as_i64());
+                    anyhow::bail!(
+                        "Command failed with exit code: {:?}",
+                        exit_code
+                    );
+                }
+                let stdout = result
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("stdout"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.trim_end_matches('\n').to_string());
+                last_outcome = BridgeOutcome { result: stdout };
+            }
+            Ok(last_outcome)
         }
         Tool::Http { .. } => {
             // PR-2c-5 fills this in.
@@ -457,21 +548,32 @@ mod tests {
         };
         let cfg = to_tools_config(&tool);
         assert_eq!(cfg.kind, "shell");
-        assert_eq!(cfg.config["cmds"], serde_json::json!("ls -la"));
+        assert_eq!(cfg.config["command"], "ls -la");
+        assert_eq!(cfg.config["shell"], "bash");
+        assert_eq!(cfg.config["capture"], true);
         assert!(cfg.timeout.is_none());
     }
 
     #[test]
-    fn to_tools_config_shell_multiple_cmds() {
+    fn to_tools_config_shell_multiple_cmds_joins_with_newlines() {
+        // The to_tools_config helper produces a SINGLE-command shape
+        // by joining; the dispatch arm instead loops per command to
+        // preserve the CLI's "fresh bash per command" semantics.
         let tool = Tool::Shell {
             cmds: CmdsList::Multiple(vec!["echo one".into(), "echo two".into()]),
         };
         let cfg = to_tools_config(&tool);
         assert_eq!(cfg.kind, "shell");
-        assert_eq!(
-            cfg.config["cmds"],
-            serde_json::json!(["echo one", "echo two"])
-        );
+        assert_eq!(cfg.config["command"], "echo one\necho two");
+    }
+
+    #[test]
+    fn shell_command_config_emits_per_cmd_shape() {
+        let cfg = shell_command_config("echo hi");
+        assert_eq!(cfg.kind, "shell");
+        assert_eq!(cfg.config["command"], "echo hi");
+        assert_eq!(cfg.config["shell"], "bash");
+        assert_eq!(cfg.config["capture"], true);
     }
 
     #[test]
@@ -549,16 +651,91 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_via_registry_returns_empty_for_unwired_kind() {
-        // PR-2c-3 wired `Tool::Rhai`.  This test still exercises the
-        // "unwired stub returns empty" branch using `Tool::Shell`,
-        // which PR-2c-4 fills in next.
+        // PR-2c-3 wired `Tool::Rhai`; PR-2c-4 wired `Tool::Shell`.
+        // The remaining stub kinds (Http, DuckDb, Playbook, Auth,
+        // Sink) still return empty.  Use `Tool::Http` here — PR-2c-5
+        // fills it in next.
         let vars = empty_vars();
         let bridge = bridge_ctx(&vars);
-        let tool = Tool::Shell {
-            cmds: CmdsList::Single("echo hi".into()),
+        let tool = Tool::Http {
+            method: "GET".into(),
+            url: "https://example.com".into(),
+            headers: HashMap::new(),
+            params: HashMap::new(),
+            body: None,
+            auth: None,
         };
         let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
         assert!(outcome.result.is_none());
+    }
+
+    // ---- PR-2c-4 — Tool::Shell bridge integration --------------------
+
+    #[tokio::test]
+    async fn dispatch_shell_single_command_returns_stdout() {
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::Shell {
+            cmds: CmdsList::Single("echo bridged".into()),
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        // The bridge trims the trailing newline that `echo` adds so
+        // the step result matches the CLI's pre-PR-2c-4 contract
+        // (per-line stdout joined without trailing whitespace).
+        assert_eq!(outcome.result, Some("bridged".into()));
+    }
+
+    #[tokio::test]
+    async fn dispatch_shell_multiple_returns_last_command_stdout() {
+        // CLI semantic: with CmdsList::Multiple, each command runs
+        // in its own bash invocation; the step result is the last
+        // command's stdout.
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::Shell {
+            cmds: CmdsList::Multiple(vec![
+                "echo first".into(),
+                "echo second".into(),
+                "echo third".into(),
+            ]),
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        assert_eq!(outcome.result, Some("third".into()));
+    }
+
+    #[tokio::test]
+    async fn dispatch_shell_failure_propagates_error() {
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::Shell {
+            cmds: CmdsList::Single("exit 7".into()),
+        };
+        let err = dispatch_via_registry(&tool, &bridge).await.unwrap_err();
+        // noetl-tools' shell tool reports non-zero exit codes by
+        // surfacing ToolResult.status == Error or by returning
+        // result with exit_code set; either way the bridge's
+        // from_tools_result converts that into an anyhow::Error.
+        assert!(
+            err.to_string().contains("shell")
+                || err.to_string().contains("exit")
+                || err.to_string().contains("failed"),
+            "error message: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_shell_single_with_newlines_runs_each_line_independently() {
+        // CLI semantic: CmdsList::Single splits on newlines into
+        // separate bash invocations.  This means `cd /tmp` on one
+        // line doesn't change the cwd of the next line.
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::Shell {
+            cmds: CmdsList::Single("echo first_line\necho second_line".into()),
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        assert_eq!(outcome.result, Some("second_line".into()));
     }
 
     #[tokio::test]

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -1,18 +1,19 @@
 use anyhow::{Context, Result};
 use duckdb::{params, Connection};
-use rhai::{Array, Dynamic, Engine, Map, Scope};
 // `Deserialize` / `Serialize` derive macros come in through the
 // `pub use noetl_executor::playbook::*` block below; no direct use
-// in this file after R-1.1 PR-2b's extraction.
+// in this file after R-1.1 PR-2b's extraction.  The `rhai::*` /
+// `BufRead*` / `Arc` / `Mutex` imports left after R-1.1 PR-2c-3
+// (rhai deletion) and PR-2c-4 (shell deletion) are scrubbed below;
+// remaining tools still need them (PR-2c-5 onwards continues
+// trimming).
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::{Arc, Mutex};
 
 // ---------------------------------------------------------------------------
 // YAML playbook types (R-1.1 PR-2a, see Appendix H of the global hybrid
@@ -775,24 +776,54 @@ impl PlaybookRunner {
     fn execute_tool(&self, tool: &Tool, context: &mut ExecutionContext) -> Result<Option<String>> {
         match tool {
             Tool::Shell { cmds } => {
-                let commands = match cmds {
-                    CmdsList::Single(cmd) => {
-                        // Split multi-line string into individual commands
-                        cmd.lines()
-                            .map(|s| s.trim())
-                            .filter(|s| !s.is_empty())
-                            .map(|s| s.to_string())
-                            .collect::<Vec<_>>()
+                // R-1.1 PR-2c-4: dispatch through the noetl-tools
+                // bridge instead of CLI's inline execute_shell_command.
+                // Per-command bash invocations preserved; bridge
+                // returns the LAST command's stdout for the step
+                // result (matches existing CLI contract).
+                //
+                // Semantic note: noetl-tools' ShellTool collects
+                // stdout + stderr and returns them at completion.
+                // The CLI's pre-PR-2c-4 implementation streamed
+                // output to the terminal line-by-line.  Long-running
+                // shell steps no longer show real-time output;
+                // documented in the PR body and on the
+                // executor-crate-architecture wiki page.
+
+                // Render each command's template first so the bridge
+                // dispatch runs the rendered commands (not the raw
+                // templates).
+                let rendered_cmds = match cmds {
+                    CmdsList::Single(cmd) => CmdsList::Single(self.render_template(cmd, context)?),
+                    CmdsList::Multiple(c) => {
+                        let mut out = Vec::with_capacity(c.len());
+                        for raw in c {
+                            out.push(self.render_template(raw, context)?);
+                        }
+                        CmdsList::Multiple(out)
                     }
-                    CmdsList::Multiple(cmds) => cmds.clone(),
                 };
 
-                let mut last_output = String::new();
-                for command in commands {
-                    let rendered_command = self.render_template(&command, context)?;
-                    last_output = self.execute_shell_command(&rendered_command)?;
-                }
-                Ok(Some(last_output))
+                let rendered_tool = Tool::Shell {
+                    cmds: rendered_cmds,
+                };
+                let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {
+                    execution_id: 0,
+                    step: "<cli-local>",
+                    variables: &context.variables,
+                    server_url: String::new(),
+                    worker_id: None,
+                    command_id: None,
+                };
+                let outcome = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        noetl_executor::tools_bridge::dispatch_via_registry(
+                            &rendered_tool,
+                            &bridge_ctx,
+                        ),
+                    )
+                })?;
+                Ok(outcome.result)
             }
             Tool::Http {
                 method,
@@ -1027,84 +1058,6 @@ impl PlaybookRunner {
         }
     }
 
-    fn execute_shell_command(&self, command: &str) -> Result<String> {
-        if self.verbose {
-            eprintln!("   🔧 Executing: {}", command);
-        }
-
-        let mut binding = Command::new("bash");
-        let cmd = binding
-            .arg("-c")
-            .arg(command)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
-
-        let cr = std::env::current_dir()?;
-
-        let cmd = cmd.current_dir(cr);
-
-        let mut child = cmd.spawn().context("Failed to spawn shell command")?;
-
-        // Clone the stdout and stderr to read in separate threads
-        let stdout = child.stdout.take().unwrap();
-        let stderr = child.stderr.take().unwrap();
-
-        // Collect stdout lines into a shared buffer so we can:
-        //   (a) keep streaming each line to stderr as the command runs
-        //       (preserves the existing UX where shell output appears
-        //       interleaved with the runner's own progress prints)
-        //   (b) return the captured stdout as the step's result, so
-        //       PlaybookRunner can store it in step_results.<step>.
-        // Without (b), every kind:shell step's result was an empty
-        // string — which made bridge result envelopes useless for
-        // anything inspection-shaped (the agent bridge's primary use
-        // case). Shared Arc<Mutex<Vec<String>>> is the simplest way
-        // to thread-safely hand stdout lines back to the main thread
-        // after the reader joins.
-        let stdout_buf = Arc::new(Mutex::new(Vec::<String>::new()));
-        let stdout_buf_clone = stdout_buf.clone();
-        let stdout_thread = std::thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                if let Ok(line) = line {
-                    eprintln!("{}", line);
-                    if let Ok(mut buf) = stdout_buf_clone.lock() {
-                        buf.push(line);
-                    }
-                }
-            }
-        });
-
-        let stderr_thread = std::thread::spawn(move || {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                if let Ok(line) = line {
-                    eprintln!("{}", line);
-                }
-            }
-        });
-
-        // Wait for both threads to finish
-        stdout_thread.join().unwrap();
-        stderr_thread.join().unwrap();
-
-        let status = child.wait()?;
-
-        if !status.success() {
-            anyhow::bail!("Command failed with exit code: {:?}", status.code());
-        }
-
-        // Reassemble the captured stdout. Lock should always succeed
-        // here because both threads have joined. Lines are joined
-        // with newlines (the reader stripped them); a trailing
-        // newline is appended only when the original output had one,
-        // which we approximate by appending an empty string and
-        // letting `.join("\n")` handle the rest.
-        let captured = stdout_buf.lock()
-            .map(|buf| buf.join("\n"))
-            .unwrap_or_default();
-        Ok(captured)
-    }
 
     /// Execute a Rhai script with access to HTTP, sleep, and utility functions
 


### PR DESCRIPTION
## Summary

Fourth sub-PR of R-1.1 PR-2c under [Strategy B](https://github.com/noetl/cli/pull/23).  Replaces the CLI's inline \`execute_shell_command\` (~79 LoC) with a dispatch through the \`noetl-tools\` bridge.  Preserves the CLI's \"fresh bash invocation per command\" semantics (independent process, no shared cwd/env state across commands within a single \`Tool::Shell\`).

\`playbook_runner.rs\` goes **1,727 → 1,656 lines (-71 net)**.

## Bridge dispatch shape

\`Tool::Shell\` arm of \`dispatch_via_registry\`:

1. Extract command list per CLI semantics:
   - \`CmdsList::Single\` splits on newlines, trims, drops empties.
   - \`CmdsList::Multiple\` uses the array as-is.
2. Loop over commands; each gets a fresh \`ToolConfig\` via the new \`shell_command_config\` helper (\`{shell: \"bash\", capture: true}\`).
3. Dispatch through \`noetl_tools::ShellTool::execute\`.
4. Unwrap \`data[\"stdout\"]\` from the typed JSON result (noetl-tools packs \`exit_code\` / \`stdout\` / \`stderr\` into \`ToolResult.data\`; the separate \`stdout\` field is unused for shell).
5. Trim the trailing \`\\n\` that \`echo\` etc. add so the step result matches the CLI's pre-PR-2c-4 contract.
6. Return the **last** command's stdout for the step result.
7. Bail on non-zero exit (matches CLI's existing \`anyhow::bail!(\"Command failed with exit code: {:?}\")\` shape).

## Semantic divergences

| Surface | CLI (pre-PR-2c-4) | noetl-tools | User-visible impact |
|---|---|---|---|
| **stdout streaming** | Line-by-line to terminal as command runs | Collected, returned at end | **Breaks** real-time output UX for long-running shell steps — users see nothing until command completes |
| Shell selection | \`bash -c\` via \`std::process::Command\` | Configurable \`shell\` field; bridge pins to \`\"bash\"\` | None — same shell, same invocation pattern |
| cwd + env | Process inherits from runner | Same default | None |
| Result envelope | Captured stdout string | \`data: {exit_code, stdout, stderr}\` | Bridge unwraps \`data[\"stdout\"]\`; transparent to runner |

The real-time streaming loss is the headline divergence and is documented in the wiki page's semantic-divergence table.  For most CLI playbooks this won't change anything observable; long-running interactive shell steps (build commands, deploys, etc.) lose progress visibility.

## Tests

**5 new unit tests** in \`tools_bridge::tests\`:

- \`dispatch_shell_single_command_returns_stdout\` (async)
- \`dispatch_shell_multiple_returns_last_command_stdout\` (async) — confirms last-command semantic
- \`dispatch_shell_single_with_newlines_runs_each_line_independently\` (async) — confirms newline-split behaviour
- \`dispatch_shell_failure_propagates_error\` (async) — confirms non-zero exit bails
- \`shell_command_config_emits_per_cmd_shape\` (sync)

**Updated tests**: \`to_tools_config_shell_single_cmd\` asserts the new \`command\` field; \`to_tools_config_shell_multiple_cmds_joins_with_newlines\` replaces the old \`cmds\`-array test.

**Stale test fixed**: \`dispatch_via_registry_returns_empty_for_unwired_kind\` used \`Tool::Shell\` as the stand-in for \"unwired\".  Now uses \`Tool::Http\` (which PR-2c-5 fills in next).

\`cargo test --workspace\`:

\`\`\`
running 41 tests (noetl bin × 2)
test result: ok. 41 passed
running 39 tests (noetl-executor)
test result: ok. 39 passed
\`\`\`

(was 34 noetl-executor tests in PR-2c-3.)

\`cargo check --workspace\` green; only pre-existing dead-code warning on \`extract_auth0_tenant_from_domain\` (unrelated).

## Import cleanup

`rhai::*`, \`BufRead\`/\`BufReader\`, \`Arc\`/\`Mutex\` imports left after PR-2c-3 (rhai deletion) and this PR (shell deletion) are scrubbed from \`playbook_runner.rs\`.  Remaining tools (\`http\`, \`duckdb\`, \`auth\`, \`sink\`, \`playbook\`) still need \`Command\`, \`Connection\`, \`params\`, etc. — PR-2c-5 through PR-2c-8 will continue trimming as each inline implementation goes.

## Next: PR-2c-5 (Tool::Http)

Higher risk than Shell because the CLI's inline HTTP uses \`curl\` subprocess; noetl-tools uses \`reqwest\` directly — different error semantics on TLS failures, DNS, timeouts, and redirect handling.

Refs noetl/cli#19 (partial — closes after PR-2d)
Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)