### PR TITLE
R-1.1 PR-2c-5: replace Tool::Http with noetl-tools bridge call

### DIFF
--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -42,12 +42,13 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
+use noetl_tools::auth::GcpAuth;
 use noetl_tools::context::ExecutionContext as ToolsExecutionContext;
 use noetl_tools::registry::{Tool as ToolsRegistryTool, ToolConfig};
 use noetl_tools::result::{ToolResult, ToolStatus};
-use noetl_tools::tools::{RhaiTool, ShellTool};
+use noetl_tools::tools::{HttpTool, RhaiTool, ShellTool};
 
-use crate::playbook::{CmdsList, Tool};
+use crate::playbook::{AuthConfig as CliAuthConfig, CmdsList, Tool};
 
 // ---------------------------------------------------------------------------
 // Bridge outcome — what the dispatch returns back to the caller.
@@ -248,15 +249,22 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             headers,
             params,
             body,
-            auth: _, // CLI's AuthConfig handled at credential-resolver layer; PR-2c-5 decides whether to inline-pass.
+            auth: _, // resolved at dispatch time into a Bearer header; not threaded through ToolConfig.auth (see PR-2c-5)
         } => (
             "http",
+            // noetl-tools' HttpConfig deserializes the method via
+            // `#[serde(rename_all = "UPPERCASE")]`, so we emit the
+            // uppercased CLI string here.  The body is wrapped as a
+            // JSON Value: if the CLI's body parses as JSON we pass the
+            // parsed Value (so reqwest serialises it as JSON with the
+            // right Content-Type); otherwise we pass it as a JSON
+            // string which noetl-tools sends verbatim as the body.
             serde_json::json!({
-                "method": method,
+                "method": method.to_uppercase(),
                 "url": url,
                 "headers": headers,
                 "params": params,
-                "body": body,
+                "body": body.as_deref().map(http_body_value),
             }),
         ),
         Tool::Playbook { path, args, input } => (
@@ -325,6 +333,128 @@ fn shell_command_config(command: &str) -> ToolConfig {
         retry: None,
         auth: None,
     }
+}
+
+/// Convert a CLI HTTP body string into a JSON [`serde_json::Value`]
+/// suitable for noetl-tools' `HttpConfig.body` field.  If the body
+/// parses as JSON, the parsed value is returned (and `reqwest` sends
+/// it with `Content-Type: application/json`).  Otherwise the body
+/// is wrapped as a [`Value::String`] which `reqwest` writes
+/// verbatim as the request body.
+fn http_body_value(body: &str) -> serde_json::Value {
+    serde_json::from_str(body).unwrap_or_else(|_| serde_json::Value::String(body.to_string()))
+}
+
+/// Resolve a CLI [`AuthConfig`] to a Bearer token using noetl-tools'
+/// [`GcpAuth`] provider.
+///
+/// CLI providers `"gcp"`, `"google"`, and `"adc"` all map to GCP
+/// Application Default Credentials.  Any other provider value
+/// returns an error matching the CLI's pre-PR-2c-5 behaviour.
+///
+/// This replaces the CLI's inline `get_auth_token` (which shelled
+/// out to `gcloud auth print-access-token`).  See semantic
+/// divergence row on the executor-crate-architecture wiki page.
+pub async fn resolve_auth_to_bearer(cfg: &CliAuthConfig) -> Result<String> {
+    match cfg.provider.as_str() {
+        "gcp" | "google" | "adc" => {
+            let gcp = GcpAuth::new();
+            let scopes: Vec<&str> = cfg.scopes.iter().map(|s| s.as_str()).collect();
+            let token = if scopes.is_empty() {
+                gcp.get_default_token()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to get GCP access token: {}", e))?
+            } else {
+                gcp.get_token(&scopes)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to get GCP access token: {}", e))?
+            };
+            Ok(token)
+        }
+        other => anyhow::bail!(
+            "unsupported auth provider: {}. Supported: gcp, google, adc",
+            other
+        ),
+    }
+}
+
+/// Build the noetl-tools [`ToolConfig`] for an HTTP request.
+///
+/// Identical to the [`to_tools_config`] `Tool::Http` arm but pulled
+/// out so the dispatch arm can also inject an `Authorization:
+/// Bearer <token>` header when a CLI `AuthConfig` is present
+/// (resolved via [`resolve_auth_to_bearer`]).
+///
+/// CLI's `auth` is intentionally NOT mapped to noetl-tools'
+/// `ToolConfig.auth` field: that field expects an `AuthConfig` with
+/// `credential` / `token` lookup against `ExecutionContext.secrets`,
+/// which CLI local mode does not populate.  Pre-resolving the
+/// token and injecting it as a header keeps the CLI's existing
+/// authority semantics (the CLI process's gcloud / ADC chain) and
+/// avoids reshaping the credential resolver path.
+fn http_tool_config(
+    method: &str,
+    url: &str,
+    headers: &HashMap<String, String>,
+    params: &HashMap<String, String>,
+    body: Option<&str>,
+    bearer: Option<&str>,
+) -> ToolConfig {
+    let mut merged_headers = headers.clone();
+    if let Some(token) = bearer {
+        merged_headers.insert(
+            "Authorization".to_string(),
+            format!("Bearer {}", token),
+        );
+    }
+    ToolConfig {
+        kind: "http".to_string(),
+        config: serde_json::json!({
+            "method": method.to_uppercase(),
+            "url": url,
+            "headers": merged_headers,
+            "params": params,
+            "body": body.map(http_body_value),
+        }),
+        timeout: None,
+        retry: None,
+        auth: None,
+    }
+}
+
+/// Reshape noetl-tools' HTTP result envelope back to the CLI's
+/// pre-PR-2c-5 shape.
+///
+/// noetl-tools' HttpTool always packs `data: {"status_code":
+/// u16, "headers": {...}, "body": <json>}` into the ToolResult,
+/// regardless of whether the HTTP response was 2xx (Success) or
+/// 4xx/5xx (Error).  The CLI's `execute_http_request` returned the
+/// envelope `{"status": <int>, "body": <json>}` for ALL HTTP
+/// responses (including 4xx/5xx) so playbook steps could branch on
+/// the status code.  We preserve that contract here: only network-
+/// transport failures bubble up as `anyhow::Error`; HTTP error
+/// statuses come back inside the JSON envelope.
+fn reshape_http_result(result: ToolResult) -> Result<BridgeOutcome> {
+    if let Some(data) = result.data {
+        let status_code = data
+            .get("status_code")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as i32;
+        let body = data
+            .get("body")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let envelope = serde_json::json!({
+            "status": status_code,
+            "body": body,
+        });
+        return Ok(BridgeOutcome {
+            result: Some(envelope.to_string()),
+        });
+    }
+    // No data — fall back to the generic from_tools_result path so
+    // we surface whatever error / stdout the tool emitted.
+    from_tools_result(result)
 }
 
 fn target_to_value(target: &crate::playbook::SinkTarget) -> serde_json::Value {
@@ -480,9 +610,53 @@ pub async fn dispatch_via_registry(
             }
             Ok(last_outcome)
         }
-        Tool::Http { .. } => {
-            // PR-2c-5 fills this in.
-            Ok(BridgeOutcome::empty())
+        Tool::Http {
+            method,
+            url,
+            headers,
+            params,
+            body,
+            auth,
+        } => {
+            // PR-2c-5: dispatch through noetl_tools::HttpTool.
+            //
+            // CLI semantics preserved:
+            // - Auth resolution via GCP ADC (gcp / google / adc).
+            // - Step result is the JSON envelope
+            //     `{"status": <int>, "body": <json-or-string>}`
+            //   regardless of HTTP status code (so playbook steps
+            //   can branch on `<step>.body.status`).
+            //
+            // Semantic divergences (documented on the executor-crate-
+            // architecture wiki page):
+            // - HTTP transport: curl subprocess → reqwest direct.
+            // - GCP token: `gcloud auth print-access-token` shellout
+            //   → `gcp_auth` crate (workload-identity aware on GKE).
+            // - Body bytes: CLI sent the body string verbatim via
+            //   `curl -d`.  noetl-tools serializes the body as JSON
+            //   when the string parses as JSON (adding Content-Type:
+            //   application/json automatically), otherwise sends it
+            //   verbatim.  See `http_body_value`.
+            let bearer = if let Some(auth_cfg) = auth {
+                Some(resolve_auth_to_bearer(auth_cfg).await?)
+            } else {
+                None
+            };
+            let config = http_tool_config(
+                method,
+                url,
+                headers,
+                params,
+                body.as_deref(),
+                bearer.as_deref(),
+            );
+            let http_tool = HttpTool::new();
+            let ctx = to_tools_context(bridge);
+            let result = http_tool
+                .execute(&config, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("http dispatch failed: {}", e))?;
+            reshape_http_result(result)
         }
         Tool::DuckDb { .. } => {
             // PR-2c-6 fills this in.
@@ -579,7 +753,7 @@ mod tests {
     #[test]
     fn to_tools_config_http_round_trips_essentials() {
         let tool = Tool::Http {
-            method: "POST".into(),
+            method: "post".into(), // lowercase to verify uppercasing
             url: "https://example.com/api".into(),
             headers: HashMap::new(),
             params: HashMap::new(),
@@ -588,9 +762,138 @@ mod tests {
         };
         let cfg = to_tools_config(&tool);
         assert_eq!(cfg.kind, "http");
+        // noetl-tools' HttpConfig.method deserializes via
+        // #[serde(rename_all = "UPPERCASE")] so the bridge always
+        // uppercases the CLI's method string.
         assert_eq!(cfg.config["method"], "POST");
         assert_eq!(cfg.config["url"], "https://example.com/api");
-        assert_eq!(cfg.config["body"], r#"{"k":"v"}"#);
+        // JSON bodies are parsed into a JSON Value so reqwest
+        // serialises them with Content-Type: application/json.
+        assert_eq!(cfg.config["body"], serde_json::json!({"k": "v"}));
+    }
+
+    #[test]
+    fn to_tools_config_http_keeps_non_json_body_as_string() {
+        let tool = Tool::Http {
+            method: "POST".into(),
+            url: "https://example.com".into(),
+            headers: HashMap::new(),
+            params: HashMap::new(),
+            body: Some("not json at all".into()),
+            auth: None,
+        };
+        let cfg = to_tools_config(&tool);
+        assert_eq!(cfg.config["body"], "not json at all");
+    }
+
+    #[test]
+    fn http_body_value_parses_json_strings() {
+        let v = http_body_value(r#"{"a":1}"#);
+        assert_eq!(v, serde_json::json!({"a": 1}));
+    }
+
+    #[test]
+    fn http_body_value_falls_back_to_string() {
+        let v = http_body_value("plain text body");
+        assert_eq!(v, serde_json::Value::String("plain text body".into()));
+    }
+
+    #[test]
+    fn http_tool_config_injects_bearer_header() {
+        let cfg = http_tool_config(
+            "GET",
+            "https://example.com",
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            Some("test-token-123"),
+        );
+        assert_eq!(cfg.kind, "http");
+        assert_eq!(
+            cfg.config["headers"]["Authorization"],
+            "Bearer test-token-123"
+        );
+    }
+
+    #[test]
+    fn http_tool_config_preserves_caller_headers_with_bearer() {
+        let mut hdrs = HashMap::new();
+        hdrs.insert("X-Trace-Id".into(), "abc123".into());
+        let cfg = http_tool_config(
+            "POST",
+            "https://example.com",
+            &hdrs,
+            &HashMap::new(),
+            None,
+            Some("token"),
+        );
+        assert_eq!(cfg.config["headers"]["X-Trace-Id"], "abc123");
+        assert_eq!(cfg.config["headers"]["Authorization"], "Bearer token");
+    }
+
+    #[test]
+    fn http_tool_config_no_auth_omits_authorization_header() {
+        let cfg = http_tool_config(
+            "GET",
+            "https://example.com",
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            None,
+        );
+        let hdrs = cfg.config["headers"].as_object().unwrap();
+        assert!(!hdrs.contains_key("Authorization"));
+    }
+
+    #[test]
+    fn reshape_http_result_extracts_envelope() {
+        let mut result = ToolResult::success(serde_json::json!({
+            "status_code": 200,
+            "headers": {},
+            "body": {"ok": true},
+        }));
+        result.exit_code = Some(0);
+        let outcome = reshape_http_result(result).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["status"], 200);
+        assert_eq!(parsed["body"], serde_json::json!({"ok": true}));
+    }
+
+    #[test]
+    fn reshape_http_result_preserves_4xx_envelope_without_erroring() {
+        // CLI contract: HTTP error statuses come back inside the
+        // `{status, body}` envelope, NOT as anyhow::Error.  Only
+        // network-transport failures bubble up.
+        let mut result = ToolResult {
+            status: ToolStatus::Error,
+            data: Some(serde_json::json!({
+                "status_code": 404,
+                "headers": {},
+                "body": {"error": "not found"},
+            })),
+            error: Some("HTTP 404 response".into()),
+            stdout: None,
+            stderr: None,
+            exit_code: Some(1),
+            duration_ms: Some(5),
+        };
+        result.exit_code = Some(1);
+        let outcome = reshape_http_result(result).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["status"], 404);
+        assert_eq!(parsed["body"], serde_json::json!({"error": "not found"}));
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_to_bearer_rejects_unknown_provider() {
+        let cfg = CliAuthConfig {
+            provider: "azure".into(),
+            scopes: vec![],
+        };
+        let err = resolve_auth_to_bearer(&cfg).await.unwrap_err();
+        assert!(err.to_string().contains("unsupported auth provider"));
     }
 
     #[test]
@@ -651,19 +954,16 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_via_registry_returns_empty_for_unwired_kind() {
-        // PR-2c-3 wired `Tool::Rhai`; PR-2c-4 wired `Tool::Shell`.
-        // The remaining stub kinds (Http, DuckDb, Playbook, Auth,
-        // Sink) still return empty.  Use `Tool::Http` here — PR-2c-5
-        // fills it in next.
+        // PR-2c-3 wired `Tool::Rhai`; PR-2c-4 wired `Tool::Shell`;
+        // PR-2c-5 wired `Tool::Http`.  The remaining stub kinds
+        // (DuckDb, Playbook, Auth, Sink) still return empty.  Use
+        // `Tool::DuckDb` here — PR-2c-6 fills it in next.
         let vars = empty_vars();
         let bridge = bridge_ctx(&vars);
-        let tool = Tool::Http {
-            method: "GET".into(),
-            url: "https://example.com".into(),
-            headers: HashMap::new(),
-            params: HashMap::new(),
-            body: None,
-            auth: None,
+        let tool = Tool::DuckDb {
+            db: ":memory:".into(),
+            query: Some("SELECT 1".into()),
+            params: vec![],
         };
         let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
         assert!(outcome.result.is_none());

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -833,30 +833,79 @@ impl PlaybookRunner {
                 body,
                 auth,
             } => {
+                // R-1.1 PR-2c-5: dispatch through the noetl-tools
+                // bridge instead of CLI's inline execute_http_request.
+                // The bridge:
+                //   - resolves CLI's `AuthConfig` to a Bearer token
+                //     via noetl-tools' `GcpAuth` (replaces the
+                //     `gcloud auth print-access-token` shellout);
+                //   - issues the HTTP request via `reqwest` (replaces
+                //     the `curl` subprocess);
+                //   - reshapes noetl-tools' `{status_code, headers,
+                //     body}` envelope to the CLI's pre-PR-2c-5
+                //     `{status, body}` shape so playbook steps can
+                //     keep branching on `<step>.body.status`.
+                //
+                // Templates (url, headers, params, body) are rendered
+                // here against the CLI's HashMap<String, String>
+                // context BEFORE handing the rendered tool to the
+                // bridge, so the bridge dispatches against fully
+                // expanded values.
                 let rendered_url = self.render_template(url, context)?;
 
                 if self.verbose {
                     eprintln!("   HTTP {} {}", method, rendered_url);
                 }
 
-                // Get auth token if auth config is provided
-                let auth_token = if let Some(auth_config) = auth {
-                    Some(self.get_auth_token(&auth_config.provider, &auth_config.scopes, context)?)
+                let mut rendered_headers = HashMap::with_capacity(headers.len());
+                for (k, v) in headers {
+                    rendered_headers.insert(k.clone(), self.render_template(v, context)?);
+                }
+                let mut rendered_params = HashMap::with_capacity(params.len());
+                for (k, v) in params {
+                    rendered_params.insert(k.clone(), self.render_template(v, context)?);
+                }
+                let rendered_body = if let Some(b) = body {
+                    Some(self.render_template(b, context)?)
                 } else {
                     None
                 };
 
-                let result = self.execute_http_request(
-                    method,
-                    &rendered_url,
-                    Some(headers),
-                    Some(params),
-                    body.as_deref(),
-                    auth_token.as_deref(),
-                    context,
-                )?;
-
-                Ok(Some(result))
+                let rendered_tool = Tool::Http {
+                    method: method.clone(),
+                    url: rendered_url,
+                    headers: rendered_headers,
+                    params: rendered_params,
+                    body: rendered_body,
+                    auth: auth.clone(),
+                };
+                let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {
+                    execution_id: 0,
+                    step: "<cli-local>",
+                    variables: &context.variables,
+                    server_url: String::new(),
+                    worker_id: None,
+                    command_id: None,
+                };
+                let outcome = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        noetl_executor::tools_bridge::dispatch_via_registry(
+                            &rendered_tool,
+                            &bridge_ctx,
+                        ),
+                    )
+                })?;
+                if self.verbose {
+                    if let Some(ref r) = outcome.result {
+                        let preview = if r.len() > 200 {
+                            format!("{}... ({} bytes)", &r[..200], r.len())
+                        } else {
+                            r.clone()
+                        };
+                        eprintln!("   Response: {}", preview);
+                    }
+                }
+                Ok(outcome.result)
             }
             Tool::Playbook { path, args, input } => {
                 let rendered_path = self.render_template(path, context)?;
@@ -939,7 +988,21 @@ impl PlaybookRunner {
                     context.set_variable("auth.project".to_string(), rendered_project);
                 }
 
-                let token = self.get_auth_token(provider, scopes, context)?;
+                // R-1.1 PR-2c-5: resolve via the same bridge helper
+                // Tool::Http uses, so both paths share the
+                // noetl-tools GcpAuth provider (gcloud shellout →
+                // gcp_auth crate).  PR-2c-8 will move Tool::Auth's
+                // full dispatch through the registry; for now we
+                // unify just the credential resolution step.
+                let auth_cfg = noetl_executor::playbook::AuthConfig {
+                    provider: provider.clone(),
+                    scopes: scopes.clone(),
+                };
+                let token = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        noetl_executor::tools_bridge::resolve_auth_to_bearer(&auth_cfg),
+                    )
+                })?;
 
                 // Store token in context for subsequent HTTP calls
                 context.set_variable("auth.token".to_string(), token.clone());
@@ -1068,154 +1131,13 @@ impl PlaybookRunner {
     // rhai_to_json_string} remain available for any future caller
     // that needs them.
 
-    fn execute_http_request(
-        &self,
-        method: &str,
-        url: &str,
-        headers: Option<&HashMap<String, String>>,
-        params: Option<&HashMap<String, String>>,
-        body: Option<&str>,
-        auth_token: Option<&str>,
-        context: &ExecutionContext,
-    ) -> Result<String> {
-        // Build curl command with status code output
-        let mut curl_args = vec![
-            "-s".to_string(),             // Silent mode
-            "-w".to_string(),             // Write format
-            "\n%{http_code}".to_string(), // Append HTTP status code
-        ];
-
-        // Add method
-        curl_args.push("-X".to_string());
-        curl_args.push(method.to_string());
-
-        // Add Authorization header if token provided
-        if let Some(token) = auth_token {
-            curl_args.push("-H".to_string());
-            curl_args.push(format!("Authorization: Bearer {}", token));
-        }
-
-        // Add headers
-        if let Some(hdrs) = headers {
-            for (key, value) in hdrs {
-                let rendered_value = self.render_template(value, context)?;
-                curl_args.push("-H".to_string());
-                curl_args.push(format!("{}: {}", key, rendered_value));
-            }
-        }
-
-        // Add body
-        if let Some(body_str) = body {
-            let rendered_body = self.render_template(body_str, context)?;
-            curl_args.push("-d".to_string());
-            curl_args.push(rendered_body);
-        }
-
-        // Build URL with params
-        let mut final_url = url.to_string();
-        if let Some(prms) = params {
-            let mut query_parts = vec![];
-            for (key, value) in prms {
-                let rendered_value = self.render_template(value, context)?;
-                query_parts.push(format!("{}={}", key, rendered_value));
-            }
-            if !query_parts.is_empty() {
-                final_url = format!("{}?{}", url, query_parts.join("&"));
-            }
-        }
-
-        curl_args.push(final_url);
-
-        if self.verbose {
-            // Redact bearer tokens in output for security
-            let redacted_args: Vec<String> = curl_args
-                .iter()
-                .map(|arg| {
-                    if arg.starts_with("Authorization: Bearer ") {
-                        "Authorization: Bearer [REDACTED]".to_string()
-                    } else {
-                        arg.clone()
-                    }
-                })
-                .collect();
-            eprintln!("   curl {}", redacted_args.join(" "));
-        }
-
-        let output = Command::new("curl")
-            .args(&curl_args)
-            .output()
-            .context("Failed to execute HTTP request (curl not available?)")?;
-
-        if !output.status.success() {
-            anyhow::bail!("HTTP request failed with exit code: {:?}", output.status.code());
-        }
-
-        let full_output = String::from_utf8_lossy(&output.stdout).to_string();
-
-        // Parse the output - body is everything before the last newline, status code is after
-        let (body_part, status_code) = if let Some(pos) = full_output.rfind('\n') {
-            let body = full_output[..pos].to_string();
-            let status = full_output[pos + 1..].trim().to_string();
-            (body, status)
-        } else {
-            (full_output.clone(), "0".to_string())
-        };
-
-        // Wrap response with status for playbook access
-        let response = serde_json::json!({
-            "status": status_code.parse::<i32>().unwrap_or(0),
-            "body": serde_json::from_str::<serde_json::Value>(&body_part).unwrap_or(serde_json::Value::String(body_part.clone()))
-        }).to_string();
-
-        if self.verbose {
-            eprintln!(
-                "   Response: {}",
-                if response.len() > 200 {
-                    format!("{}... ({} bytes)", &response[..200], response.len())
-                } else {
-                    response.clone()
-                }
-            );
-        }
-
-        Ok(response)
-    }
-
-    /// Get authentication token from the specified provider
-    fn get_auth_token(&self, provider: &str, scopes: &[String], _context: &ExecutionContext) -> Result<String> {
-        match provider {
-            "gcp" | "google" | "adc" => {
-                // Use gcloud to get access token
-                let mut args = vec!["auth", "print-access-token"];
-
-                // Add scopes if specified
-                let scopes_str = if !scopes.is_empty() {
-                    scopes.join(",")
-                } else {
-                    String::new()
-                };
-
-                if !scopes_str.is_empty() {
-                    args.push("--scopes");
-                    // Need to keep scopes_str alive
-                }
-
-                let output = Command::new("gcloud")
-                    .args(&args)
-                    .output()
-                    .context("Failed to get GCP access token (gcloud CLI not available?)")?;
-
-                if !output.status.success() {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    anyhow::bail!("Failed to get GCP access token: {}", stderr);
-                }
-
-                let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                Ok(token)
-            }
-            _ => anyhow::bail!("Unsupported auth provider: {}. Supported: gcp, google, adc", provider),
-        }
-    }
+    // R-1.1 PR-2c-5: `execute_http_request` (curl subprocess) and
+    // `get_auth_token` (`gcloud auth print-access-token` shellout)
+    // were replaced with a call into
+    // `noetl_executor::tools_bridge::dispatch_via_registry` which
+    // routes through `noetl_tools::HttpTool` (reqwest) and
+    // `noetl_tools::auth::GcpAuth` (gcp_auth crate) respectively.
+    // See the Tool::Http arm of `execute_tool` above for the wiring.
 
     /// Execute a DuckDB query and return results as JSON
     fn execute_duckdb_query(&self, db_path: &PathBuf, query: &str, _params: &[String]) -> Result<String> {


### PR DESCRIPTION
## Summary

Fifth sub-PR of the Strategy B incremental tool replacement
(after [#23](https://github.com/noetl/cli/pull/23) PR-2c-1 dep + scaffold, [#24](https://github.com/noetl/cli/pull/24) PR-2c-2 adapters,
[#25](https://github.com/noetl/cli/pull/25) PR-2c-3 Rhai, [#26](https://github.com/noetl/cli/pull/26) PR-2c-4 Shell).  Routes the CLI's
`Tool::Http` execution through the noetl-tools registry via
`noetl-executor::tools_bridge`.

### What changes in the bridge

- **HTTP dispatch**: `Tool::Http { method, url, headers, params, body, auth }`
  now lowers into `noetl_tools::tools::HttpTool::execute`.  Method
  uppercased to match noetl-tools' `HttpConfig` schema.  Body
  parsed as JSON if possible (giving reqwest the
  `Content-Type: application/json` shortcut), otherwise sent
  verbatim as a string.
- **Auth resolution**: `CliAuthConfig { provider, scopes }` resolves
  to a `Bearer` token via `noetl_tools::auth::GcpAuth`
  (gcp_auth crate).  Token injected as an `Authorization` header
  on the rendered request -- intentionally not threaded through
  `ToolConfig.auth` because that field expects a credential lookup
  against `ExecutionContext.secrets` which CLI local mode does not
  populate.
- **Result envelope**: noetl-tools' `data: {status_code, headers, body}`
  reshapes back to the CLI's pre-PR-2c-5 `{status, body}` shape so
  playbook steps can keep branching on `<step>.body.status`.  4xx /
  5xx responses come back inside the envelope -- only network-
  transport failures bubble up as `anyhow::Error`, matching the
  CLI's existing contract.

### What changes in playbook_runner.rs

- `Tool::Http` arm in `execute_tool` switches to
  `tokio::task::block_in_place(|| Handle::current().block_on(
   noetl_executor::tools_bridge::dispatch_via_registry(...)))`
  -- same shape as the rhai and shell arms.
- `execute_http_request` deleted (~113 LoC).
- `get_auth_token` deleted (~35 LoC).
- `Tool::Auth` arm also routes through `resolve_auth_to_bearer`
  so both Tool::Http and Tool::Auth share the GCP ADC code path.
  PR-2c-8 will replace Tool::Auth's full dispatch through the
  registry.

### Tests

- 9 new unit tests in `tools_bridge`:
  - `http_body_value_parses_json_strings`
  - `http_body_value_falls_back_to_string`
  - `http_tool_config_injects_bearer_header`
  - `http_tool_config_preserves_caller_headers_with_bearer`
  - `http_tool_config_no_auth_omits_authorization_header`
  - `reshape_http_result_extracts_envelope`
  - `reshape_http_result_preserves_4xx_envelope_without_erroring`
  - `to_tools_config_http_keeps_non_json_body_as_string`
  - `resolve_auth_to_bearer_rejects_unknown_provider`
- Updated `dispatch_via_registry_returns_empty_for_unwired_kind` to
  use `Tool::DuckDb` (PR-2c-6 wires it next).
- Updated `to_tools_config_http_round_trips_essentials` for the new
  uppercase-method + JSON-Value-body shape.

Workspace: 130 tests passing (48 noetl-executor + 41 noetl + 41 ntl).

### Documented semantic divergences

| Surface | CLI behaviour (pre-PR-2c-5) | noetl-tools behaviour | User-visible impact |
|---|---|---|---|
| HTTP transport | `curl` subprocess | `reqwest` direct | Same envelope on success; different error shape on transport failure (anyhow message vs curl exit code) |
| GCP token | `gcloud auth print-access-token` shellout | `gcp_auth` crate (workload-identity aware) | Better on GKE pods; equivalent on hosts with `gcloud` configured |
| JSON request body | Sent verbatim via `curl -d`; caller had to set Content-Type | Auto-detected as JSON; reqwest sets Content-Type | Most callers were already sending JSON with `Content-Type: application/json`; transparent |

The transport switch matches the PR-2c-3 (#25) rhai HTTP helpers
divergence, just applied to the explicit `Tool::Http` surface
instead of inline Rhai helpers.

### Stats so far (executor crate)

- `playbook_runner.rs`: 2,688 -> 1,641 (-1,047 net across PR-2a +
  PR-2b + PR-2c-3 + PR-2c-4 + PR-2c-5)
- noetl-executor tests: 0 -> 48 across PR-1 + PR-2a + PR-2b + PR-2c-1
  + PR-2c-2 + PR-2c-3 + PR-2c-4 + PR-2c-5
- Workspace-wide: 130 passing

## Test plan

- [x] `cargo build --workspace` (clean -- only pre-existing
  `extract_auth0_tenant_from_domain` dead-code warning unrelated to
  this PR)
- [x] `cargo test --workspace` (130 passing, 0 failing)
- [ ] Manual smoke against a real HTTP endpoint after merge (CI
  doesn't have a guaranteed-reachable target; reviewers can spot-
  check)
- [ ] Per `agents/rules/deployment-validation.md`, no container
  image rebuilds here -- the executor crate ships in the CLI
  workspace and there's no GKE deployable affected by this PR.
  Container changes return in PR-2c-7 (Tool::Playbook) and PR-2c-8
  (Tool::Auth + Tool::Sink) which integrate with the catalog
  server.

Refs noetl/ai-meta#36 -- R-1.1 PR-2c umbrella.
See noetl/cli#19 -- R-1.1 sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)