### PR TITLE
R-1.1 PR-2c-6: replace Tool::DuckDb with noetl-tools bridge call

### DIFF
--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -46,7 +46,7 @@ use noetl_tools::auth::GcpAuth;
 use noetl_tools::context::ExecutionContext as ToolsExecutionContext;
 use noetl_tools::registry::{Tool as ToolsRegistryTool, ToolConfig};
 use noetl_tools::result::{ToolResult, ToolStatus};
-use noetl_tools::tools::{HttpTool, RhaiTool, ShellTool};
+use noetl_tools::tools::{DuckdbTool, HttpTool, RhaiTool, ShellTool};
 
 use crate::playbook::{AuthConfig as CliAuthConfig, CmdsList, Tool};
 
@@ -276,11 +276,30 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             }),
         ),
         Tool::DuckDb { db, query, params } => (
+            // noetl-tools' DuckdbConfig schema uses `db_path` (not
+            // `db`), `query` is required (so we substitute an empty
+            // string when the CLI doesn't carry one — the dispatch
+            // arm short-circuits in that case), and params are
+            // `Vec<serde_json::Value>` rather than `Vec<String>`.
+            // Conversion is faithful: a CLI string param becomes a
+            // JSON string value bound at the `?` placeholder by
+            // noetl-tools' DuckdbTool.
+            //
+            // Compatibility note: the CLI's pre-PR-2c-6
+            // `execute_duckdb_query` accepted but **ignored** the
+            // `params` field (signature was `_params: &[String]`).
+            // The bridge now binds them, which is a feature gain
+            // documented in the PR body and on the executor-crate-
+            // architecture wiki page.
             "duckdb",
             serde_json::json!({
-                "db": db,
-                "query": query,
-                "params": params,
+                "db_path": db,
+                "query": query.clone().unwrap_or_default(),
+                "params": params
+                    .iter()
+                    .map(|p| serde_json::Value::String(p.clone()))
+                    .collect::<Vec<_>>(),
+                "as_objects": true,
             }),
         ),
         Tool::Rhai { code, args } => (
@@ -455,6 +474,90 @@ fn reshape_http_result(result: ToolResult) -> Result<BridgeOutcome> {
     // No data — fall back to the generic from_tools_result path so
     // we surface whatever error / stdout the tool emitted.
     from_tools_result(result)
+}
+
+/// Build a [`ToolConfig`] for a DuckDB query.
+///
+/// Used by the `Tool::DuckDb` dispatch arm.  Path resolution
+/// (playbook-relative vs absolute) and `mkdir -p` of the parent
+/// directory are handled at the CLI call site BEFORE the bridge is
+/// invoked, so this helper receives an already-resolved absolute
+/// path string (or `:memory:` for in-memory mode).
+fn duckdb_tool_config(
+    db_path: &str,
+    query: &str,
+    params: &[String],
+) -> ToolConfig {
+    ToolConfig {
+        kind: "duckdb".to_string(),
+        config: serde_json::json!({
+            "db_path": db_path,
+            "query": query,
+            "params": params
+                .iter()
+                .map(|p| serde_json::Value::String(p.clone()))
+                .collect::<Vec<_>>(),
+            // CLI's pre-PR-2c-6 SELECT result shape was an array of
+            // JSON objects keyed by column name; `as_objects: true`
+            // matches that.  `reshape_duckdb_result` then unwraps
+            // the noetl-tools envelope back to the raw array.
+            "as_objects": true,
+        }),
+        timeout: None,
+        retry: None,
+        auth: None,
+    }
+}
+
+/// Reshape noetl-tools' DuckDB result envelope back to the CLI's
+/// pre-PR-2c-6 shape.
+///
+/// noetl-tools' DuckdbTool returns:
+/// - SELECT / WITH: `data: {"columns": [...], "rows": [{...}, ...],
+///   "row_count": N}`
+/// - non-SELECT:    `data: {"affected_rows": N}`
+///
+/// The CLI's `execute_duckdb_query` returned:
+/// - SELECT / WITH: a JSON array of objects (pretty-printed)
+/// - non-SELECT:    the literal string `{"status": "ok"}`
+///
+/// `reshape_duckdb_result` maps the former onto the latter so
+/// playbook steps that read `<step>.result[0].col_name` keep
+/// working.  `affected_rows` from the noetl-tools envelope is
+/// dropped on purpose — the CLI never exposed it.
+fn reshape_duckdb_result(result: ToolResult) -> Result<BridgeOutcome> {
+    let data = match result.data {
+        Some(d) => d,
+        None => return from_tools_result(result),
+    };
+
+    if let Some(rows) = data.get("rows").and_then(|v| v.as_array()) {
+        // SELECT path.  Return the rows array as a pretty-printed
+        // JSON string — matches the CLI's
+        // `serde_json::to_string_pretty(&results)`.
+        let pretty = serde_json::to_string_pretty(rows)?;
+        return Ok(BridgeOutcome { result: Some(pretty) });
+    }
+
+    if data.get("affected_rows").is_some() {
+        // Non-SELECT path.  CLI emitted the literal `{"status":
+        // "ok"}` here; preserve that.
+        return Ok(BridgeOutcome {
+            result: Some(r#"{"status": "ok"}"#.to_string()),
+        });
+    }
+
+    // Unknown shape — fall back to the generic from_tools_result
+    // path so we still surface whatever the tool emitted.
+    from_tools_result(ToolResult {
+        status: result.status,
+        data: Some(data),
+        error: result.error,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exit_code: result.exit_code,
+        duration_ms: result.duration_ms,
+    })
 }
 
 fn target_to_value(target: &crate::playbook::SinkTarget) -> serde_json::Value {
@@ -658,9 +761,44 @@ pub async fn dispatch_via_registry(
                 .map_err(|e| anyhow::anyhow!("http dispatch failed: {}", e))?;
             reshape_http_result(result)
         }
-        Tool::DuckDb { .. } => {
-            // PR-2c-6 fills this in.
-            Ok(BridgeOutcome::empty())
+        Tool::DuckDb { db, query, params } => {
+            // PR-2c-6: dispatch through noetl_tools::DuckdbTool.
+            //
+            // CLI semantics preserved:
+            // - The CLI's call site already resolved playbook-
+            //   relative paths (`resolve_duckdb_path`) and ran
+            //   `mkdir -p` on the parent directory before invoking
+            //   the bridge, so `db` here is an absolute path
+            //   string ready to hand to DuckDB.
+            // - SELECT / WITH queries return a JSON array of
+            //   objects (pretty-printed).
+            // - Non-SELECT queries return the literal envelope
+            //   `{"status": "ok"}` (CLI never exposed
+            //   noetl-tools' `affected_rows`).
+            // - Empty / missing query short-circuits to an empty
+            //   outcome, matching the CLI arm's
+            //   `if let Some(query_str) = query` guard.
+            //
+            // Feature gain: CLI's pre-PR-2c-6 inline impl took a
+            // `_params: &[String]` and silently ignored it.  The
+            // bridge now binds those params as JSON values at
+            // `?` placeholders.  Playbooks that had a stale
+            // `params:` list under a query without `?` placeholders
+            // continue to work (DuckDB ignores extra params); any
+            // playbook that *intended* the params would now see
+            // them applied — documented in the PR body.
+            let query = match query {
+                Some(q) if !q.trim().is_empty() => q,
+                _ => return Ok(BridgeOutcome::empty()),
+            };
+            let config = duckdb_tool_config(db, query, params);
+            let duckdb_tool = DuckdbTool::new();
+            let ctx = to_tools_context(bridge);
+            let result = duckdb_tool
+                .execute(&config, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("duckdb dispatch failed: {}", e))?;
+            reshape_duckdb_result(result)
         }
         Tool::Playbook { .. } => {
             // PR-2c-7 fills this in.
@@ -896,6 +1034,142 @@ mod tests {
         assert!(err.to_string().contains("unsupported auth provider"));
     }
 
+    // ---- PR-2c-6 — Tool::DuckDb bridge integration -------------------
+
+    #[test]
+    fn duckdb_tool_config_emits_noetl_tools_schema() {
+        let cfg = duckdb_tool_config(
+            ":memory:",
+            "SELECT 1",
+            &["arg1".to_string()],
+        );
+        assert_eq!(cfg.kind, "duckdb");
+        assert_eq!(cfg.config["db_path"], ":memory:");
+        assert_eq!(cfg.config["query"], "SELECT 1");
+        assert_eq!(cfg.config["as_objects"], true);
+        assert_eq!(
+            cfg.config["params"],
+            serde_json::json!([serde_json::Value::String("arg1".into())])
+        );
+    }
+
+    #[test]
+    fn to_tools_config_duckdb_carries_path_and_query() {
+        let tool = Tool::DuckDb {
+            db: "warehouse.db".into(),
+            query: Some("SELECT count(*) FROM orders".into()),
+            params: vec![],
+        };
+        let cfg = to_tools_config(&tool);
+        assert_eq!(cfg.kind, "duckdb");
+        assert_eq!(cfg.config["db_path"], "warehouse.db");
+        assert_eq!(cfg.config["query"], "SELECT count(*) FROM orders");
+        assert_eq!(cfg.config["as_objects"], true);
+    }
+
+    #[test]
+    fn to_tools_config_duckdb_missing_query_becomes_empty_string() {
+        let tool = Tool::DuckDb {
+            db: ":memory:".into(),
+            query: None,
+            params: vec![],
+        };
+        let cfg = to_tools_config(&tool);
+        assert_eq!(cfg.config["query"], "");
+    }
+
+    #[test]
+    fn reshape_duckdb_result_select_returns_rows_array() {
+        let result = ToolResult::success(serde_json::json!({
+            "columns": ["id", "name"],
+            "rows": [
+                {"id": 1, "name": "alice"},
+                {"id": 2, "name": "bob"},
+            ],
+            "row_count": 2
+        }));
+        let outcome = reshape_duckdb_result(result).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        let arr = parsed.as_array().expect("result is an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["id"], 1);
+        assert_eq!(arr[0]["name"], "alice");
+        assert_eq!(arr[1]["name"], "bob");
+    }
+
+    #[test]
+    fn reshape_duckdb_result_select_empty_returns_empty_array() {
+        let result = ToolResult::success(serde_json::json!({
+            "columns": ["id"],
+            "rows": [],
+            "row_count": 0
+        }));
+        let outcome = reshape_duckdb_result(result).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn reshape_duckdb_result_non_select_returns_status_envelope() {
+        let result = ToolResult::success(serde_json::json!({
+            "affected_rows": 3
+        }));
+        let outcome = reshape_duckdb_result(result).unwrap();
+        // CLI returned the literal `{"status": "ok"}` string for
+        // non-SELECT queries; `affected_rows` is intentionally
+        // dropped (CLI never exposed it, so playbooks can't depend
+        // on it).
+        assert_eq!(outcome.result.as_deref(), Some(r#"{"status": "ok"}"#));
+    }
+
+    #[tokio::test]
+    async fn dispatch_duckdb_select_returns_rows_array() {
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::DuckDb {
+            db: ":memory:".into(),
+            query: Some("SELECT 1 AS num, 'hello' AS msg".into()),
+            params: vec![],
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+        let arr = parsed.as_array().expect("result is an array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["num"], 1);
+        assert_eq!(arr[0]["msg"], "hello");
+    }
+
+    #[tokio::test]
+    async fn dispatch_duckdb_missing_query_returns_empty_outcome() {
+        // Mirrors the CLI arm's `if let Some(query_str) = query` guard:
+        // a Tool::DuckDb with no query falls through to None.
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::DuckDb {
+            db: ":memory:".into(),
+            query: None,
+            params: vec![],
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        assert!(outcome.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_duckdb_empty_query_returns_empty_outcome() {
+        let vars = empty_vars();
+        let bridge = bridge_ctx(&vars);
+        let tool = Tool::DuckDb {
+            db: ":memory:".into(),
+            query: Some("   ".into()), // whitespace only
+            params: vec![],
+        };
+        let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
+        assert!(outcome.result.is_none());
+    }
+
     #[test]
     fn to_tools_config_rhai_carries_code() {
         let tool = Tool::Rhai {
@@ -955,15 +1229,16 @@ mod tests {
     #[tokio::test]
     async fn dispatch_via_registry_returns_empty_for_unwired_kind() {
         // PR-2c-3 wired `Tool::Rhai`; PR-2c-4 wired `Tool::Shell`;
-        // PR-2c-5 wired `Tool::Http`.  The remaining stub kinds
-        // (DuckDb, Playbook, Auth, Sink) still return empty.  Use
-        // `Tool::DuckDb` here — PR-2c-6 fills it in next.
+        // PR-2c-5 wired `Tool::Http`; PR-2c-6 wired `Tool::DuckDb`.
+        // The remaining stub kinds (Playbook, Auth, Sink) still
+        // return empty.  Use `Tool::Playbook` here — PR-2c-7 fills
+        // it in next.
         let vars = empty_vars();
         let bridge = bridge_ctx(&vars);
-        let tool = Tool::DuckDb {
-            db: ":memory:".into(),
-            query: Some("SELECT 1".into()),
-            params: vec![],
+        let tool = Tool::Playbook {
+            path: "non-existent.yaml".into(),
+            args: HashMap::new(),
+            input: HashMap::new(),
         };
         let outcome = dispatch_via_registry(&tool, &bridge).await.unwrap();
         assert!(outcome.result.is_none());

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -953,6 +953,19 @@ impl PlaybookRunner {
                 Ok(None)
             }
             Tool::DuckDb { db, query, params } => {
+                // R-1.1 PR-2c-6: dispatch through the noetl-tools
+                // bridge instead of CLI's inline execute_duckdb_query.
+                //
+                // The CLI keeps owning:
+                //  - playbook-relative path resolution
+                //    (`resolve_duckdb_path`), and
+                //  - the parent-directory `mkdir -p` step that the
+                //    bridge does NOT replicate (noetl-tools' DuckdbTool
+                //    just opens the path as-given).
+                //
+                // The bridge owns the query execution + result
+                // reshape so the CLI's SELECT/non-SELECT envelope
+                // shape is preserved.
                 let rendered_db = self.render_template(db, context)?;
                 let db_path = self.resolve_duckdb_path(&rendered_db)?;
 
@@ -960,18 +973,50 @@ impl PlaybookRunner {
                     eprintln!("   DuckDB: {}", db_path.display());
                 }
 
-                if let Some(query_str) = query {
-                    let rendered_query = self.render_template(query_str, context)?;
-                    let rendered_params: Vec<String> = params
-                        .iter()
-                        .map(|p| self.render_template(p, context))
-                        .collect::<Result<Vec<_>>>()?;
+                let query_str = match query {
+                    Some(q) => q,
+                    None => return Ok(None),
+                };
+                let rendered_query = self.render_template(query_str, context)?;
+                let rendered_params: Vec<String> = params
+                    .iter()
+                    .map(|p| self.render_template(p, context))
+                    .collect::<Result<Vec<_>>>()?;
 
-                    let result = self.execute_duckdb_query(&db_path, &rendered_query, &rendered_params)?;
-                    Ok(Some(result))
-                } else {
-                    Ok(None)
+                // Ensure parent directory exists — matches the CLI's
+                // pre-PR-2c-6 behaviour where `execute_duckdb_query`
+                // ran `fs::create_dir_all(parent)` before opening
+                // the connection.
+                if let Some(parent) = db_path.parent() {
+                    fs::create_dir_all(parent)?;
                 }
+
+                let db_path_str = db_path
+                    .to_str()
+                    .context("DuckDB path is not valid UTF-8")?
+                    .to_string();
+                let rendered_tool = Tool::DuckDb {
+                    db: db_path_str,
+                    query: Some(rendered_query),
+                    params: rendered_params,
+                };
+                let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {
+                    execution_id: 0,
+                    step: "<cli-local>",
+                    variables: &context.variables,
+                    server_url: String::new(),
+                    worker_id: None,
+                    command_id: None,
+                };
+                let outcome = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        noetl_executor::tools_bridge::dispatch_via_registry(
+                            &rendered_tool,
+                            &bridge_ctx,
+                        ),
+                    )
+                })?;
+                Ok(outcome.result)
             }
             Tool::Auth {
                 provider,
@@ -1139,62 +1184,14 @@ impl PlaybookRunner {
     // `noetl_tools::auth::GcpAuth` (gcp_auth crate) respectively.
     // See the Tool::Http arm of `execute_tool` above for the wiring.
 
-    /// Execute a DuckDB query and return results as JSON
-    fn execute_duckdb_query(&self, db_path: &PathBuf, query: &str, _params: &[String]) -> Result<String> {
-        // Ensure parent directory exists
-        if let Some(parent) = db_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let conn = Connection::open(db_path).context("Failed to open DuckDB database")?;
-
-        if self.verbose {
-            eprintln!("   Query: {}", query);
-        }
-
-        // Check if it's a SELECT query or a modification query
-        let query_upper = query.trim().to_uppercase();
-        if query_upper.starts_with("SELECT") || query_upper.starts_with("WITH") {
-            let mut stmt = conn.prepare(query).context("Failed to prepare query")?;
-            let column_count = stmt.column_count();
-            let column_names: Vec<String> = (0..column_count)
-                .map(|i| stmt.column_name(i).map_or("?".to_string(), |v| v.to_string()))
-                .collect();
-
-            let rows = stmt.query_map(params![], |row| {
-                let mut row_map = serde_json::Map::new();
-                for (i, col_name) in column_names.iter().enumerate() {
-                    let value: duckdb::types::Value = row.get(i)?;
-                    let json_value = match value {
-                        duckdb::types::Value::Null => serde_json::Value::Null,
-                        duckdb::types::Value::Boolean(b) => serde_json::Value::Bool(b),
-                        duckdb::types::Value::TinyInt(n) => serde_json::Value::Number(n.into()),
-                        duckdb::types::Value::SmallInt(n) => serde_json::Value::Number(n.into()),
-                        duckdb::types::Value::Int(n) => serde_json::Value::Number(n.into()),
-                        duckdb::types::Value::BigInt(n) => serde_json::Value::Number(n.into()),
-                        duckdb::types::Value::Float(f) => serde_json::Number::from_f64(f as f64)
-                            .map(serde_json::Value::Number)
-                            .unwrap_or(serde_json::Value::Null),
-                        duckdb::types::Value::Double(f) => serde_json::Number::from_f64(f)
-                            .map(serde_json::Value::Number)
-                            .unwrap_or(serde_json::Value::Null),
-                        duckdb::types::Value::Text(s) => serde_json::Value::String(s),
-                        _ => serde_json::Value::String(format!("{:?}", value)),
-                    };
-                    row_map.insert(col_name.clone(), json_value);
-                }
-                Ok(serde_json::Value::Object(row_map))
-            })?;
-
-            let results: Vec<serde_json::Value> = rows.filter_map(|r| r.ok()).collect();
-            let json = serde_json::to_string_pretty(&results)?;
-            Ok(json)
-        } else {
-            // Execute non-SELECT query (CREATE, INSERT, UPDATE, DELETE)
-            conn.execute(query, params![]).context("Failed to execute query")?;
-            Ok(r#"{"status": "ok"}"#.to_string())
-        }
-    }
+    // R-1.1 PR-2c-6: `execute_duckdb_query` was replaced with a
+    // call into `noetl_executor::tools_bridge::dispatch_via_registry`
+    // which routes through `noetl_tools::tools::DuckdbTool`.  The
+    // bridge's `reshape_duckdb_result` preserves the CLI's
+    // SELECT-rows-array / `{"status": "ok"}` envelope shape.  Path
+    // resolution + `mkdir -p` stay at the CLI call site because the
+    // bridge has no knowledge of the playbook directory.  See the
+    // Tool::DuckDb arm of `execute_tool` above for the wiring.
 
     /// Resolve DuckDB path relative to playbook or as absolute
     fn resolve_duckdb_path(&self, db_path: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

Sixth sub-PR of the Strategy B incremental tool replacement
(after [#23](https://github.com/noetl/cli/pull/23) PR-2c-1 dep + scaffold, [#24](https://github.com/noetl/cli/pull/24) PR-2c-2 adapters,
[#25](https://github.com/noetl/cli/pull/25) PR-2c-3 Rhai, [#26](https://github.com/noetl/cli/pull/26) PR-2c-4 Shell, [#27](https://github.com/noetl/cli/pull/27) PR-2c-5 Http).  Routes
the CLI's `Tool::DuckDb` execution through the noetl-tools
registry via `noetl-executor::tools_bridge`.

### What changes in the bridge

- **DuckDB dispatch**: `Tool::DuckDb { db, query, params }` lowers
  into `noetl_tools::tools::DuckdbTool::execute`.  The schema
  difference (`db` → `db_path`, `params: Vec<String>` →
  `Vec<serde_json::Value>`, mandatory non-empty `query`) is handled
  by the new `duckdb_tool_config` helper.
- **Empty-query short-circuit**: `query: None` or whitespace-only
  returns `BridgeOutcome::empty()`, mirroring the CLI's existing
  `if let Some(query_str) = query` guard.  Behaviour at the step-
  result level is unchanged.
- **Result reshape** (`reshape_duckdb_result`): noetl-tools'
  `{columns, rows, row_count}` envelope maps back to the CLI's
  pre-PR-2c-6 shape — SELECT / WITH returns the rows array
  pretty-printed; non-SELECT returns the literal `{"status": "ok"}`
  string.  Playbook steps that read `<step>.result[0].col_name`
  keep working.

### What changes in playbook_runner.rs

- `Tool::DuckDb` arm in `execute_tool` switches to
  `tokio::task::block_in_place(|| Handle::current().block_on(
   noetl_executor::tools_bridge::dispatch_via_registry(...)))`.
- CLI keeps owning `resolve_duckdb_path` (playbook-relative path
  resolution) and the parent-directory `mkdir -p` because the
  bridge has no knowledge of the playbook directory.
- `execute_duckdb_query` deleted (~55 LoC).
- `Connection` / `params!` imports stay — `sink_to_duckdb` (the
  Sink arm's DuckDB write path, slated for PR-2c-8) still uses
  them directly.

### Feature gain — params are no longer silently dropped

CLI's pre-PR-2c-6 `execute_duckdb_query` accepted the `params:
&[String]` field but the signature was `_params` — values went
nowhere.  The bridge now binds them as JSON values at `?`
placeholders in the SQL.  Playbooks that *intended* the params
would now see them applied.  Playbooks that had a stale `params:`
list under a query with no `?` placeholders continue to work
(DuckDB ignores extra params).

### Tests

- 9 new unit tests in `tools_bridge`:
  - `duckdb_tool_config_emits_noetl_tools_schema`
  - `to_tools_config_duckdb_carries_path_and_query`
  - `to_tools_config_duckdb_missing_query_becomes_empty_string`
  - `reshape_duckdb_result_select_returns_rows_array`
  - `reshape_duckdb_result_select_empty_returns_empty_array`
  - `reshape_duckdb_result_non_select_returns_status_envelope`
  - `dispatch_duckdb_select_returns_rows_array`
  - `dispatch_duckdb_missing_query_returns_empty_outcome`
  - `dispatch_duckdb_empty_query_returns_empty_outcome`
- Updated `dispatch_via_registry_returns_empty_for_unwired_kind` to
  use `Tool::Playbook` (PR-2c-7 wires it next).

Workspace: 139 tests passing (57 noetl-executor + 41 noetl + 41 ntl).

### Documented semantic divergences

| Surface | CLI behaviour (pre-PR-2c-6) | noetl-tools behaviour | User-visible impact |
|---|---|---|---|
| Connection lifecycle | Fresh `Connection::open(path)` per call | Same | Transparent |
| SELECT result envelope | JSON array of row objects (pretty-printed) | `{columns, rows, row_count}` | Transparent — bridge unwraps to CLI's shape |
| Non-SELECT result envelope | `{"status": "ok"}` literal string | `{"affected_rows": N}` | Transparent — bridge maps back; `affected_rows` dropped (CLI never exposed it) |
| Params binding | `_params: &[String]` — silently ignored | Bound as JSON at `?` placeholders | **Feature gain** — playbooks that intended params will now see them applied |
| Path resolution + mkdir | `resolve_duckdb_path` + `fs::create_dir_all(parent)` | Open as-given, no mkdir | CLI keeps owning these — handled at the call site before dispatch |

### Scope notes

The Sink arm's `sink_to_duckdb` write path (used by
`Tool::Sink { target: SinkTarget::DuckDb, .. }`) is intentionally
NOT migrated in this PR.  It stays inline for PR-2c-8 alongside
the rest of the Sink tool replacement.

### Stats so far (executor crate)

- `playbook_runner.rs`: 2,688 → 1,638 (-1,050 net across PR-2a +
  PR-2b + PR-2c-3 + PR-2c-4 + PR-2c-5 + PR-2c-6)
- noetl-executor tests: 0 → 57 across PR-1 + PR-2a + PR-2b + PR-2c-1
  + PR-2c-2 + PR-2c-3 + PR-2c-4 + PR-2c-5 + PR-2c-6
- Workspace-wide: 139 passing

## Test plan

- [x] `cargo build --workspace` (clean — only pre-existing
  `extract_auth0_tenant_from_domain` dead-code warning unrelated to
  this PR)
- [x] `cargo test --workspace` (139 passing, 0 failing)
- [x] Round-trip SELECT covered by
  `dispatch_duckdb_select_returns_rows_array`
- [x] None / whitespace short-circuit covered by
  `dispatch_duckdb_missing_query_returns_empty_outcome` and
  `dispatch_duckdb_empty_query_returns_empty_outcome`
- [ ] Per `agents/rules/deployment-validation.md`, no container
  image rebuilds here — pure CLI workspace change with no GKE
  deployable affected.

Refs noetl/ai-meta#30 — Appendix H umbrella.
See noetl/cli#19 — R-1.1 sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)