### PR TITLE
R-1.2 PR-1: publish noetl-executor 0.1.0 (fixes broken release pipeline)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,59 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+
+      # ---- noetl-executor (workspace member) --------------------------
+      # R-1.2 PR-1: noetl-executor must publish before the noetl bin
+      # because the bin depends on it from crates.io.  The executor's
+      # version is independent of the bin's version -- it tracks the
+      # shared-execution-core crate's API, not the CLI's release
+      # cadence.
+      - name: Get noetl-executor version
+        id: executor_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXECUTOR_VERSION=$(grep -E '^version = ' executor/Cargo.toml | head -1 | cut -d'"' -f2)
+          echo "version=${EXECUTOR_VERSION}" >> "${GITHUB_OUTPUT}"
+      - name: Check noetl-executor version on crates.io
+        id: executor_check
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.executor_version.outputs.version }}"
+          if curl -fsS -H "User-Agent: noetl-cli-release" "https://crates.io/api/v1/crates/noetl-executor/${VERSION}" >/dev/null; then
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Publish noetl-executor
+        if: ${{ env.CRATES_IO_TOKEN != '' && steps.executor_check.outputs.already_published != 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_TOKEN }}
+        shell: bash
+        run: |
+          set +e
+          OUTPUT="$(cargo publish -p noetl-executor 2>&1)"
+          STATUS=$?
+          set -e
+
+          echo "${OUTPUT}"
+
+          if [[ ${STATUS} -eq 0 ]]; then
+            exit 0
+          fi
+
+          if echo "${OUTPUT}" | grep -Eqi "already uploaded|already exists"; then
+            echo "noetl-executor version already published; continuing."
+            exit 0
+          fi
+
+          exit ${STATUS}
+      - name: Skip noetl-executor publish (already on crates.io)
+        if: ${{ steps.executor_check.outputs.already_published == 'true' }}
+        run: echo "noetl-executor version ${{ steps.executor_version.outputs.version }} already on crates.io; skipping."
+
+      # ---- noetl + ntl binaries (workspace root) ----------------------
       - name: Check crate version on crates.io
         id: crate_check
         shell: bash
@@ -62,7 +115,7 @@ jobs:
           set -euo pipefail
           CRATE_NAME=$(grep -E '^name = ' Cargo.toml | head -1 | cut -d'"' -f2)
           VERSION="${{ needs.verify-version.outputs.version }}"
-          if curl -fsS "https://crates.io/api/v1/crates/${CRATE_NAME}/${VERSION}" >/dev/null; then
+          if curl -fsS -H "User-Agent: noetl-cli-release" "https://crates.io/api/v1/crates/${CRATE_NAME}/${VERSION}" >/dev/null; then
             echo "already_published=true" >> "${GITHUB_OUTPUT}"
           else
             echo "already_published=false" >> "${GITHUB_OUTPUT}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,13 @@ path = "src/main.rs"
 # noetl-executor::playbook so both the CLI and noetl-worker (R-1.3)
 # operate on the same data model.  See Appendix H of the global hybrid
 # cloud blueprint.
-noetl-executor = { path = "executor" }
+#
+# Both `path` and `version` are specified per Cargo's recommendation
+# for workspace members that are also published to crates.io: local
+# dev uses the path; `cargo publish` resolves against the crates.io
+# version constraint.  R-1.2 PR-1 set the executor's `publish = true`
+# so this dependency can be satisfied from crates.io.
+noetl-executor = { path = "executor", version = "0.1" }
 
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -4,8 +4,16 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"
-description = "NoETL shared execution core - drives playbook commands from local YAML or NATS"
-publish = false
+homepage = "https://noetl.io"
+description = "NoETL shared execution core — utilities and types shared between the noetl CLI's local-mode runner and the noetl-worker NATS pull consumer."
+readme = "README.md"
+keywords = ["noetl", "etl", "workflow", "automation", "executor"]
+categories = ["development-tools"]
+# R-1.2 PR-1: published to crates.io so `noetl` (the bin in this
+# workspace) can satisfy its dependency from crates.io, and so the
+# noetl-worker repo can depend on `noetl-executor = "0.1"` for R-1.2
+# onwards.  See § H.10 of Appendix H of the global hybrid cloud
+# blueprint for the architectural rationale.
 
 [dependencies]
 # Async runtime; matches the CLI's tokio surface so the shared crate


### PR DESCRIPTION
## Summary

**Pipeline-fix PR + opening move of R-1.2.**

Three consecutive release workflow runs have failed at the `publish-crate` step with:

```
error: failed to verify manifest at `/Cargo.toml`
   all dependencies must have a version requirement specified when publishing.
   dependency `noetl-executor` does not specify a version
```

The `noetl` bin has been stuck at crates.io@`2.17.1` (May 29) while local `Cargo.toml` rolled forward through `2.18.0` … `2.24.0` (the full R-1.1 PR-2 series, eight sub-PRs). That's seven CLI versions of finished work that reached GitHub Releases / git tags but never reached `cargo install noetl`.

## Diagnosis

`noetl-executor` was introduced as a workspace member with `publish = false` (pre-production gating during R-1.1). The bin's dep was a bare path:

```toml
noetl-executor = { path = "executor" }
```

`cargo publish` rejects this — published crates may not depend on path deps without a version constraint, since the published bin needs to resolve its deps from crates.io after upload.

## Fix

Three coordinated changes:

**1. `executor/Cargo.toml`** — flip `publish = true` (was `false`); add the crates.io metadata the registry expects (`homepage`, `readme = "README.md"`, `keywords`, `categories`); expand `description` to explain the crate's role.

**2. `Cargo.toml` (noetl bin)** — add a version constraint alongside the existing path dep:

```toml
noetl-executor = { path = "executor", version = "0.1" }
```

Cargo's recommended shape for workspace members that also publish to crates.io: local dev uses the path; `cargo publish` resolves against the version constraint.

**3. `.github/workflows/release.yml`** — extend the `publish-crate` job to publish `noetl-executor` BEFORE the bin. Same publish-or-skip logic the bin step already uses:

- read the executor's version from `executor/Cargo.toml` (independent of the workflow's `version` input, which targets the bin)
- check crates.io for that version via the `/api/v1/crates/noetl-executor/$VERSION` endpoint
- publish if missing; treat "already exists" as success

The executor's release cadence is intentionally independent of the bin's so the crate can stay at `0.1.0` across many bin versions, then bump for actual API changes per Cargo's 0.x semver convention.

## Verification

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 174 passing (80 noetl-executor unit + 12 noetl-executor integration + 41 noetl + 41 ntl); no regressions
- [x] `cargo publish --dry-run --allow-dirty -p noetl-executor` — packages 16 files, 247.7 KiB / 62.5 KiB compressed; dry-run upload succeeds
- [x] `cargo publish --dry-run --allow-dirty` for the bin — fails as expected with \"no matching package named \`noetl-executor\` found\" until `noetl-executor 0.1.0` actually lands on crates.io. Once this PR merges and the release workflow runs, the executor publishes first and the bin's resolution succeeds on the second step.

## What this unblocks

- **Immediate**: all accumulated CLI versions (`2.18.0` → `2.24.0`) can reach crates.io as soon as the workflow runs after merge.
- **R-1.2 PR-2**: noetl-worker repo can add `noetl-executor = \"0.1\"` to its `Cargo.toml` and start consolidating its inline condition evaluator + event envelope onto the shared crate.
- **Wider R-1.x**: subsequent sub-PRs that touch the executor crate can ship a new patch version per Cargo's 0.x convention.

## Why publish 0.1.0 now

The crate's public API was deliberately churning through R-1.1's sub-PRs. R-1.1 is now complete (noetl/cli#19 closed via #31), so the surface is settled enough to commit to a `0.1.x` semver line. The crate ships with:

- README that documents scope, module layout, § H.10 rationale.
- lib.rs top-level docs listing every module + which kinds dispatch vs bail.
- 92 tests (80 unit + 12 integration) locking the contract.

Subsequent breaking changes will bump the minor version per Cargo's 0.x convention.

## Test plan

- [x] Local: build + test workspace
- [x] Local: dry-run publish noetl-executor
- [ ] Post-merge: confirm the release workflow run succeeds end-to-end
- [ ] Post-merge: `cargo install noetl --version 2.24.0` works against crates.io

Refs noetl/ai-meta#30 — Appendix H umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)