### PR TITLE
R-1.2 PR-2a: align execution_id to i64 (noetl-executor 0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/main.rs"
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.1" }
+noetl-executor = { path = "executor", version = "0.2" }
 
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-executor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"

--- a/executor/src/events.rs
+++ b/executor/src/events.rs
@@ -20,9 +20,17 @@ use chrono::{DateTime, Utc};
 /// One event the executor emits.  Keep field naming aligned with the
 /// Python side (`noetl.event` table columns) so envelopes can be
 /// projected by either stack.
+///
+/// R-1.2 PR-2a: `execution_id` is now `i64` (matching the Python
+/// `noetl.event.execution_id` bigint column, the CLI's
+/// `BridgeContext.execution_id`, the worker's
+/// `CommandNotification.execution_id`, and
+/// `noetl_tools::context::ExecutionContext.execution_id`).  In 0.1.x
+/// the field was `String` as a placeholder; cross-binary work in
+/// R-1.2 makes the alignment load-bearing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutorEvent {
-    pub execution_id: String,
+    pub execution_id: i64,
     pub event_type: String,
     /// Step name (`node_id` / `node_name` in the Python projector).
     pub step: String,
@@ -46,11 +54,11 @@ pub trait EventSink: Send + Sync {
 /// through every call site.
 pub struct EventEmitter {
     pub sink: std::sync::Arc<dyn EventSink>,
-    pub execution_id: String,
+    pub execution_id: i64,
 }
 
 impl EventEmitter {
-    pub fn new(execution_id: String, sink: std::sync::Arc<dyn EventSink>) -> Self {
+    pub fn new(execution_id: i64, sink: std::sync::Arc<dyn EventSink>) -> Self {
         Self { sink, execution_id }
     }
 
@@ -62,7 +70,7 @@ impl EventEmitter {
         context: serde_json::Value,
     ) -> Result<()> {
         let event = ExecutorEvent {
-            execution_id: self.execution_id.clone(),
+            execution_id: self.execution_id,
             event_type: event_type.to_string(),
             step: step.to_string(),
             status: status.to_string(),
@@ -94,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn noop_sink_accepts_any_event() {
         let sink: Arc<dyn EventSink> = Arc::new(NoopSink);
-        let emitter = EventEmitter::new("exec_test".into(), sink);
+        let emitter = EventEmitter::new(12345, sink);
         emitter
             .emit(
                 "batch.completed",

--- a/executor/src/runtime.rs
+++ b/executor/src/runtime.rs
@@ -16,8 +16,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Identifies one playbook execution end-to-end.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ExecutionId(pub String);
+///
+/// R-1.2 PR-2a: aliased to `i64` to match the Python `noetl.event` /
+/// `noetl.command` table columns (bigint), the CLI's
+/// `BridgeContext.execution_id` (i64), `noetl_tools::context::
+/// ExecutionContext.execution_id` (i64), and the worker's
+/// `CommandNotification.execution_id` (i64).  The `pub struct
+/// ExecutionId(pub String)` newtype in 0.1.x was a placeholder while
+/// nothing crossed the boundary; R-1.2 starts cross-binary work so
+/// the type alignment matters.
+pub type ExecutionId = i64;
 
 /// Trait for resolving keychain credential aliases at step-execution
 /// time.  Mirrors the Python-side `noetl.core.credential_refs`

--- a/executor/src/worker/source.rs
+++ b/executor/src/worker/source.rs
@@ -28,7 +28,11 @@ pub struct Command {
     pub command_id: String,
 
     /// Execution this command belongs to.
-    pub execution_id: String,
+    ///
+    /// R-1.2 PR-2a: aligned to `i64` to match the worker's
+    /// `CommandNotification.execution_id` and the Python
+    /// `noetl.command.execution_id` bigint column.
+    pub execution_id: i64,
 
     /// Step name from the playbook (e.g. `"fetch_calendar"`).
     pub step: String,


### PR DESCRIPTION
## Summary

Type-alignment PR that bumps `noetl-executor` from 0.1.0 to 0.2.0.

R-1.1 left the crate with three different `execution_id`
representations because nothing crossed the boundary yet:

| Location | Type in 0.1.x |
|---|---|
| `events::ExecutorEvent.execution_id` | `String` |
| `events::EventEmitter.execution_id` | `String` |
| `runtime::ExecutionId` | `pub struct ExecutionId(pub String)` |
| `worker::source::Command.execution_id` | `String` |
| `tools_bridge::BridgeContext.execution_id` | `i64` ✓ |

R-1.2 PR-2 (worker adopts the executor) makes the inconsistency
load-bearing: the worker uses `i64` for execution_id throughout
(`CommandNotification.execution_id`, `WorkerEvent.execution_id`,
`ControlPlaneClient.emit_event`), and the Python `noetl.event` /
`noetl.command` tables are `bigint`. Without this PR, every seam
between worker and executor would need an ad-hoc `i64.to_string()` /
`string.parse::<i64>()` conversion.

## Changes

- `executor/src/runtime.rs`: `pub struct ExecutionId(pub String)` →
  `pub type ExecutionId = i64`.  The 0.1.x newtype was a
  placeholder; nothing depends on its name-binding semantics.
- `executor/src/events.rs`:
  - `ExecutorEvent.execution_id`: `String` → `i64`
  - `EventEmitter.execution_id`: `String` → `i64`
  - `EventEmitter::new(execution_id: i64, sink)` signature
  - `emit()` body uses Copy semantics in place of `.clone()`
- `executor/src/worker/source.rs`: `Command.execution_id`:
  `String` → `i64`
- `executor/Cargo.toml`: `version = "0.1.0"` → `"0.2.0"` (0.x
  semver treats minor bumps as breaking changes)
- `Cargo.toml` (bin): `noetl-executor = { path = "executor",
  version = "0.2" }` — workspace builds against local 0.2 source;
  `cargo publish` resolves against the published 0.2 line.
- Single test fixture changed: `EventEmitter::new("exec_test".into(), sink)`
  → `EventEmitter::new(12345, sink)` (only test change the type
  forced).

## Alignment matrix after this PR

| Location | Type |
|---|---|
| `events::ExecutorEvent.execution_id` | `i64` ✓ |
| `events::EventEmitter.execution_id` | `i64` ✓ |
| `runtime::ExecutionId` (type alias) | `i64` ✓ |
| `worker::source::Command.execution_id` | `i64` ✓ |
| `tools_bridge::BridgeContext.execution_id` | `i64` ✓ |
| (worker) `CommandNotification.execution_id` | `i64` ✓ |
| (worker) `WorkerEvent.execution_id` | `i64` ✓ |
| (noetl-tools) `ExecutionContext.execution_id` | `i64` ✓ |
| (Python) `noetl.event.execution_id` | `bigint` ✓ |
| (Python) `noetl.command.execution_id` | `bigint` ✓ |

All execution_id representations now agree on the wire format.

## Verification

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace`: 174 passing (80 noetl-executor unit
  + 12 noetl-executor integration + 41 noetl + 41 ntl). No
  behaviour change — just the type narrowing.

## What this unblocks

- **PR-2b** (noetl/cli): extend `executor::condition` with a
  structured `Condition` + 12-variant `Operator` enum so the
  worker can share its case-condition surface with the executor;
  bump to 0.2.1.
- **PR-2c** (noetl/worker): replace `WorkerEvent` with
  `ExecutorEvent` directly — no type conversion at the seam.
- **PR-2d** (noetl/worker): `NatsSubscriber` implements
  `executor::worker::source::CommandSource`; main loop becomes
  generic over the trait so integration tests can use mock
  sources.

## Release-pipeline note

PR #32 fixed the broken release pipeline by adding a publish step
for `noetl-executor` ahead of the bin.  As of this PR opening,
**noetl-executor 0.1.0 is live on crates.io** (published at
2026-05-30T06:04:44Z via the manual workflow_dispatch on v2.24.0).
Once #33 merges, the next semantic-release tag will publish
`noetl-executor 0.2.0` and the bin alongside, via the same
two-stage publish-crate job.

Refs noetl/ai-meta#30 — Appendix H umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)