### PR TITLE
R-1.2 PR-EE-1: enrich ExecutorEvent with event_id / worker_id / meta (0.3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-executor"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"

--- a/executor/src/events.rs
+++ b/executor/src/events.rs
@@ -25,20 +25,71 @@ use chrono::{DateTime, Utc};
 /// `noetl.event.execution_id` bigint column, the CLI's
 /// `BridgeContext.execution_id`, the worker's
 /// `CommandNotification.execution_id`, and
-/// `noetl_tools::context::ExecutionContext.execution_id`).  In 0.1.x
-/// the field was `String` as a placeholder; cross-binary work in
-/// R-1.2 makes the alignment load-bearing.
+/// `noetl_tools::context::ExecutionContext.execution_id`).
+///
+/// R-1.2 PR-EE-1 (0.3.1): adds the optional fields the Python
+/// `EventEmitRequest` (and the Rust `noetl-server` `EventRequest`)
+/// already expect — `event_id`, `worker_id`, `meta`.  All are
+/// `Option` + `#[serde(default, skip_serializing_if =
+/// "Option::is_none")]` so older wire-format consumers deserialize
+/// cleanly and producers that don't populate them omit them from
+/// the JSON entirely.  This step is the additive prerequisite for
+/// the cross-repo event envelope reconciliation tracked on
+/// [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExecutorEvent {
+    /// Execution this event belongs to.  Matches the
+    /// `noetl.event.execution_id` bigint column.
     pub execution_id: i64,
+
+    /// Event type (e.g. `"step.enter"`, `"call.done"`,
+    /// `"step.exit"`, `"command.completed"`, `"command.failed"`).
+    /// Python side uses an `EventType` enum but Rust accepts the
+    /// raw string; the server validates against the enum when
+    /// projecting.
     pub event_type: String,
+
     /// Step name (`node_id` / `node_name` in the Python projector).
     pub step: String,
+
+    /// Lifecycle status (e.g. `"STARTED"`, `"COMPLETED"`,
+    /// `"FAILED"`).
     pub status: String,
-    /// Wall-clock when the event was produced.
+
+    /// Wall-clock when the event was produced.  Stamped at emit
+    /// time so the event log preserves per-component ordering
+    /// even across server-clock skew.
     pub created_at: DateTime<Utc>,
-    /// Free-form payload; the projector reads typed fields out of this.
+
+    /// Free-form payload; the projector reads typed fields out
+    /// of this.  Renamed from the worker's `payload` field to
+    /// match the Python `EventEmitRequest.context` field; serde
+    /// alias accepts either name on the wire.
+    #[serde(alias = "payload")]
     pub context: serde_json::Value,
+
+    /// Application-side snowflake id for this event.  Per
+    /// [`agents/rules/observability.md`][rule] Principle 3,
+    /// the emitting process generates this BEFORE the row hits
+    /// the database so spans / metrics / cross-component
+    /// correlation can use it immediately.  `None` falls back to
+    /// the DB-side default (existing `gen_snowflake()` function).
+    ///
+    /// [rule]: https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<i64>,
+
+    /// Worker that emitted the event (worker pod's id, or
+    /// `"cli-local"` for CLI mode).  Used for shard-aware queries
+    /// + diagnostic correlation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_id: Option<String>,
+
+    /// Free-form metadata that doesn't belong in `context` —
+    /// retry counts, parent-event refs, catalog ids.  Matches the
+    /// Python `EventEmitRequest.meta` field 1:1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Value>,
 }
 
 #[async_trait]
@@ -76,6 +127,9 @@ impl EventEmitter {
             status: status.to_string(),
             created_at: Utc::now(),
             context,
+            event_id: None,
+            worker_id: None,
+            meta: None,
         };
         self.sink.emit(event).await
     }
@@ -112,5 +166,104 @@ mod tests {
             )
             .await
             .expect("noop emit");
+    }
+
+    // ---- R-1.2 PR-EE-1 — envelope enrichment ------------------------
+
+    fn dummy_event() -> ExecutorEvent {
+        ExecutorEvent {
+            execution_id: 1,
+            event_type: "step.enter".to_string(),
+            step: "fetch".to_string(),
+            status: "STARTED".to_string(),
+            created_at: Utc::now(),
+            context: serde_json::json!({}),
+            event_id: None,
+            worker_id: None,
+            meta: None,
+        }
+    }
+
+    #[test]
+    fn new_optional_fields_omit_from_serialized_json_when_none() {
+        let event = dummy_event();
+        let json = serde_json::to_value(&event).unwrap();
+        // The new optional fields should not appear in the wire
+        // format when None — older consumers shouldn't see
+        // unfamiliar keys.
+        assert!(json.get("event_id").is_none(), "event_id omitted");
+        assert!(json.get("worker_id").is_none(), "worker_id omitted");
+        assert!(json.get("meta").is_none(), "meta omitted");
+    }
+
+    #[test]
+    fn new_optional_fields_serialize_when_present() {
+        let event = ExecutorEvent {
+            event_id: Some(478775660589088777),
+            worker_id: Some("worker-1".to_string()),
+            meta: Some(serde_json::json!({"attempts": 2})),
+            ..dummy_event()
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["event_id"], serde_json::json!(478775660589088777_i64));
+        assert_eq!(json["worker_id"], "worker-1");
+        assert_eq!(json["meta"]["attempts"], 2);
+    }
+
+    #[test]
+    fn deserializes_payload_alias_into_context() {
+        // Older wire format uses `payload`; new envelope uses
+        // `context`.  Serde alias lets both deserialize.
+        let json = serde_json::json!({
+            "execution_id": 5,
+            "event_type": "step.enter",
+            "step": "s",
+            "status": "STARTED",
+            "created_at": "2026-05-31T00:00:00Z",
+            "payload": {"foo": "bar"},
+        });
+        let event: ExecutorEvent = serde_json::from_value(json).unwrap();
+        assert_eq!(event.context, serde_json::json!({"foo": "bar"}));
+    }
+
+    #[test]
+    fn deserializes_missing_optional_fields_with_none() {
+        // Wire format without event_id / worker_id / meta should
+        // deserialize cleanly with the new fields set to None.
+        let json = serde_json::json!({
+            "execution_id": 5,
+            "event_type": "step.enter",
+            "step": "s",
+            "status": "STARTED",
+            "created_at": "2026-05-31T00:00:00Z",
+            "context": {},
+        });
+        let event: ExecutorEvent = serde_json::from_value(json).unwrap();
+        assert!(event.event_id.is_none());
+        assert!(event.worker_id.is_none());
+        assert!(event.meta.is_none());
+    }
+
+    #[test]
+    fn round_trips_with_all_optional_fields_set() {
+        let original = ExecutorEvent {
+            execution_id: 478775660589088776,
+            event_type: "command.completed".to_string(),
+            step: "fetch_calendar".to_string(),
+            status: "COMPLETED".to_string(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-05-31T03:14:15Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            context: serde_json::json!({"result": {"items": 42}}),
+            event_id: Some(478775660589088777),
+            worker_id: Some("worker-prod-7".to_string()),
+            meta: Some(serde_json::json!({"attempts": 3, "parent_event_id": "478775660589088770"})),
+        };
+        let json = serde_json::to_value(&original).unwrap();
+        let parsed: ExecutorEvent = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.execution_id, original.execution_id);
+        assert_eq!(parsed.event_id, original.event_id);
+        assert_eq!(parsed.worker_id, original.worker_id);
+        assert_eq!(parsed.meta, original.meta);
     }
 }


### PR DESCRIPTION
## Summary

First in the cross-repo **event envelope reconciliation** series tracked on [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30).  Enriches `noetl_executor::events::ExecutorEvent` with the optional fields the Python `EventEmitRequest` + Rust noetl-server `EventRequest` already expect, so the worker's future switch lands cleanly without translation overhead.

## The four-shape divergence (status today)

| Source | Type | execution_id | event-name field | extra fields |
|---|---|---|---|---|
| **noetl-executor 0.3.0** | `ExecutorEvent` | `i64` | `event_type` | `step`, `status`, `created_at`, `context` |
| **noetl-server (Rust)** | `EventRequest` | `String` | `name` ← diverges | `payload`, `meta`, `worker_id`, `actionable`, `informative` |
| **noetl/noetl (Python)** | `EventEmitRequest` | `str` | `event_type` | `event_id`, `meta`, `payload`, `catalog_id`, `parent_event_id`, … |
| **noetl-worker** | `WorkerEvent` | `i64` | `event_type` | `payload` |

Worker → server today probably works via pydantic lenient JSON coercion (i64 deserializes to str, etc.) but it's never been audited end-to-end.  The reconciliation gets all four shapes onto the same wire format.

## What lands in PR-EE-1

`ExecutorEvent` gains three new optional fields:

```rust
pub struct ExecutorEvent {
    // ... existing ...
    pub execution_id: i64,
    pub event_type: String,
    pub step: String,
    pub status: String,
    pub created_at: DateTime<Utc>,
    #[serde(alias = "payload")]              // NEW alias
    pub context: serde_json::Value,

    // NEW optional fields:
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub event_id: Option<i64>,

    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub worker_id: Option<String>,

    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub meta: Option<serde_json::Value>,
}
```

| Field | Why | Source-of-truth |
|---|---|---|
| `event_id: Option<i64>` | Application-side snowflake (per `observability.md` Principle 3) for span/metric correlation BEFORE the DB write | Python `EventEmitRequest.event_id` |
| `worker_id: Option<String>` | Emitting worker pod id ("worker-prod-7" / "cli-local") for diagnostic queries | Python `EventEmitRequest.worker_id`, Rust `EventRequest.worker_id` |
| `meta: Option<serde_json::Value>` | Free-form (retries, parent_event_id, catalog_id) | Python `EventEmitRequest.meta`, Rust `EventRequest.meta` |

Plus a serde alias: `#[serde(alias = "payload")]` on `context` so the worker's pre-EE `WorkerEvent.payload` deserializes cleanly into `ExecutorEvent.context` without translation.

## Why this is non-breaking

- New fields are `Option<...>` + `#[serde(default, skip_serializing_if = "Option::is_none")]`.
  - **Producers** that don't populate them omit them from JSON entirely → existing consumers see no new keys.
  - **Consumers** that see the old wire format without these keys deserialize cleanly with `None`.
- `payload` alias is additive — `context` is still the canonical name; `payload` just works as an input alternative.

Minor bump 0.3.0 → **0.3.1**.  The bin's `noetl-executor = { ..., version = "0.3" }` constraint is unchanged.

## Tests

5 new unit tests in `events::tests`:

- `new_optional_fields_omit_from_serialized_json_when_none` — wire format stays minimal when fields are None
- `new_optional_fields_serialize_when_present` — JSON shapes match the schemas (i64 / String / free-form)
- `deserializes_payload_alias_into_context` — `payload` key on the wire deserializes into the new `context` field
- `deserializes_missing_optional_fields_with_none` — older wire format deserializes cleanly with defaults
- `round_trips_with_all_optional_fields_set` — full envelope round-trips through serde without data loss

Workspace: 198 tests passing (104 noetl-executor unit + 12 integration + 41 noetl + 41 ntl).  +5 net from this PR; zero regressions.

## Reconciliation roadmap

This is **PR 1 of 4** in the cross-repo series:

| PR | Repo | Scope |
|---|---|---|
| EE-1 (this) | noetl/cli | Enrich `ExecutorEvent` additively (0.3.1) |
| EE-2 | noetl/server (Rust) | Rename `name` → `event_type` with serde alias; accept new optional fields |
| EE-4 | noetl/noetl (Python) | Align `EventEmitRequest.event_type` field naming |
| EE-3 | noetl/worker | Replace `WorkerEvent` with `ExecutorEvent` re-export; send the new wire shape |

**Server-side PRs (EE-2 + EE-4) ship additively first** so they accept both shapes during the migration window.  Worker (EE-3) switches **last**, when both servers are ready.

Refs [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30) — Appendix H umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
