### PR TITLE
feat(workspace): add noetl-arrow-cache crate (R-2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -373,6 +373,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -739,7 +745,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -755,7 +761,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1398,6 +1404,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -2151,6 +2163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,11 +2222,24 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2232,7 +2266,7 @@ dependencies = [
  "dirs 5.0.1",
  "dotenvy",
  "duckdb",
- "nix",
+ "nix 0.29.0",
  "noetl-executor",
  "rand 0.8.6",
  "ratatui",
@@ -2251,6 +2285,22 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "noetl-arrow-cache"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "shared_memory",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -2372,7 +2422,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2839,7 +2889,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm 0.27.0",
@@ -2879,7 +2929,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2989,7 +3039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
 dependencies = [
  "ahash 0.8.12",
- "bitflags",
+ "bitflags 2.11.1",
  "no-std-compat",
  "num-traits",
  "once_cell",
@@ -3094,7 +3144,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3107,7 +3157,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3256,7 +3306,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3269,7 +3319,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3421,6 +3471,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_memory"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8593196da75d9dc4f69349682bd4c2099f8cde114257d1ef7ef1b33d1aba54"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "nix 0.23.2",
+ "rand 0.8.6",
+ "win-sys",
 ]
 
 [[package]]
@@ -3667,7 +3730,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3921,7 +3984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4300,7 +4363,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4349,6 +4412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows 0.34.0",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4381,6 +4453,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
 
 [[package]]
 name = "windows"
@@ -4607,6 +4692,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4622,6 +4713,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4655,6 +4752,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4670,6 +4773,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4706,6 +4815,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4798,7 +4913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,16 @@
 [workspace]
-# Cargo workspace.  The CLI binary remains the root package; `executor`
-# is a workspace member crate that hosts the shared execution core
-# (LocalPlaybookSource for the CLI's `noetl run --runtime local` path
-# and NatsCommandSource for noetl-worker — see Appendix H of the
-# global hybrid cloud blueprint, https://noetl.dev/docs/architecture/
-# noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint).
-members = ["executor"]
+# Cargo workspace.  The CLI binary remains the root package; sibling
+# crates host shared infrastructure:
+#
+# - `executor` — the shared execution core (LocalPlaybookSource for
+#   the CLI's `noetl run --runtime local` path, NatsCommandSource for
+#   noetl-worker).  See Appendix H of the global hybrid cloud
+#   blueprint, https://noetl.dev/docs/architecture/
+#   noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint
+# - `arrow-cache` — Rust mirror of Python's
+#   `ArrowIpcSharedMemoryCache`.  Same-node zero-copy IPC for the
+#   columnar data plane.  R-2.1 in the Rust migration roadmap.
+members = ["executor", "arrow-cache"]
 
 [package]
 name = "noetl"

--- a/arrow-cache/Cargo.toml
+++ b/arrow-cache/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "noetl-arrow-cache"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/noetl/cli"
+homepage = "https://noetl.io"
+description = "NoETL Arrow IPC shared-memory cache — Rust mirror of Python's ArrowIpcSharedMemoryCache for zero-copy same-node data plane"
+keywords = ["arrow", "ipc", "shared-memory", "cache", "noetl"]
+categories = ["caching", "data-structures"]
+readme = "README.md"
+
+[dependencies]
+# Core types + datetime — match the conventions used by sibling
+# crates `noetl-executor` and `noetl-tools` so call sites can use
+# the same `chrono::Utc::now()` flows for lease expiry.
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# POSIX shared memory.  The `shared_memory` crate wraps
+# `shm_open`/`mmap` cross-platform (Linux + macOS) and matches
+# the on-disk layout Python's `multiprocessing.shared_memory.SharedMemory`
+# produces — same `/dev/shm/<name>` files, same `shm_open(O_CREAT)`
+# semantics.
+shared_memory = "0.12"
+
+# Error handling — Anyhow is used by the rest of the workspace.
+anyhow = "1.0"
+thiserror = "2.0"
+
+# Tracing follows the workspace conventions for spans + structured
+# logs (per `agents/rules/observability.md`).
+tracing = "0.1"
+
+# SHA-2 for the schema-digest portion of the shm name.  Matches
+# Python's `hashlib.sha256(payload).hexdigest()[:8]`.
+sha2 = "0.10"
+
+# Hex encoding for the digest.
+hex = "0.4"
+
+[dev-dependencies]
+# `tempfile` for namespacing test shm regions away from real
+# deployments.
+tempfile = "3"

--- a/arrow-cache/README.md
+++ b/arrow-cache/README.md
@@ -1,0 +1,74 @@
+# noetl-arrow-cache
+
+Rust mirror of Python's
+[`ArrowIpcSharedMemoryCache`](https://github.com/noetl/noetl/blob/main/noetl/core/storage/ipc_cache.py).
+Same-node zero-copy IPC for the NoETL columnar data plane — R-2.1
+of the Rust migration roadmap (Appendix H of the global hybrid
+cloud blueprint).
+
+## What this gives you
+
+A small in-process cache keyed by an `IpcHint` token.  Producers
+push Arrow IPC byte streams into shared memory; colocated consumers
+read them back without going through the durable storage path.
+The hint is JSON-serialisable and crosses process boundaries
+through any transport (NATS, HTTP, files, etc.) — but the bytes
+themselves stay on the same machine.
+
+## Cross-stack compatibility
+
+The shm name format, lease policy, eviction order, and `IpcHint`
+JSON shape match the Python implementation 1:1 so a hint produced
+by either stack deserialises cleanly on the other.  Both sides
+use POSIX `shm_open` + `mmap` (Python via
+`multiprocessing.shared_memory.SharedMemory`, Rust via the
+`shared_memory` crate).
+
+## Example
+
+```rust
+use noetl_arrow_cache::{ArrowIpcSharedMemoryCache, IpcHint};
+
+// One cache per process.  Defaults read NOETL_IPC_CACHE_BUDGET_BYTES,
+// HOSTNAME, NOETL_NODE_ID from env.
+let cache = ArrowIpcSharedMemoryCache::new();
+
+// Produce — `payload` is the Arrow IPC stream bytes from
+// `noetl_tools::arrow_codec::encode_record_batch`.
+let hint = cache.put_arrow_ipc(
+    payload_bytes,
+    schema_digest,
+    Some(row_count as u64),
+    None, // default lease (60s)
+)?;
+
+// Pass `hint` over the wire to a colocated consumer ...
+
+// Consume — same node, same hint JSON, gets the bytes back.
+let bytes = cache.get(&hint)?;
+```
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `NOETL_IPC_CACHE_BUDGET_BYTES` | 268435456 (256 MB) | Soft budget; cache evicts oldest-by-lease until it fits. |
+| `HOSTNAME` | `unknown` | Stamped onto every produced hint as the `producer` field. |
+| `NOETL_NODE_ID` / `NODE_NAME` / `K8S_NODE_NAME` / `HOSTNAME` | `unknown` | Producer node identity; consumers refuse to attach when this differs from their local node id. |
+
+## What this crate is NOT
+
+- Not a durable store.  Bytes evict on lease expiry + budget pressure.
+  The durable copy (e.g. SeaweedFS / GCS / disk) is the authority;
+  this cache is an acceleration for the colocated hot path.
+- Not an Arrow IPC codec.  Encoding / decoding lives in
+  `noetl-tools::arrow_codec`; this crate moves opaque bytes.
+- Not network-aware.  The `IpcHint.node_id` field tells consumers
+  to fall back to the durable copy when the producer is on a
+  different node.
+
+## See also
+
+- [`noetl-tools::arrow_codec`](https://docs.rs/noetl-tools) — Arrow IPC encode/decode (the layer that produces the bytes this cache stores).
+- Python counterpart: [`noetl.core.storage.ipc_cache`](https://github.com/noetl/noetl/blob/main/noetl/core/storage/ipc_cache.py).
+- Appendix H, § R-2: [global hybrid cloud blueprint](https://noetl.dev/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint).

--- a/arrow-cache/src/cache.rs
+++ b/arrow-cache/src/cache.rs
@@ -1,0 +1,581 @@
+//! [`ArrowIpcSharedMemoryCache`] — the put/get/delete surface.
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use sha2::{Digest, Sha256};
+use shared_memory::ShmemConf;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::hint::IpcHint;
+
+const DEFAULT_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
+const DEFAULT_LEASE_SECONDS: f64 = 60.0;
+const NAMESPACE_PREFIX_MAX: usize = 12;
+
+/// Construction parameters for [`ArrowIpcSharedMemoryCache`].
+///
+/// All fields have sensible defaults sourced from environment when
+/// applicable — call sites only override what they need.
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Short prefix attached to every shm name (max 12 chars after
+    /// sanitisation; matches Python's behaviour).  Defaults to
+    /// `"noetl"`.
+    pub namespace: String,
+
+    /// Budget in bytes the cache stays under via lease + LRU eviction.
+    /// Defaults to `NOETL_IPC_CACHE_BUDGET_BYTES` env var or 256 MB.
+    pub budget_bytes: u64,
+
+    /// Lease length applied to entries when the caller doesn't
+    /// specify one explicitly.  Defaults to 60s — same as Python.
+    pub default_lease_seconds: f64,
+
+    /// Identity of the producing process.  Defaults to the
+    /// `HOSTNAME` env var or `"unknown"`.  Stamped onto every
+    /// produced hint for diagnostic correlation.
+    pub producer: String,
+
+    /// Producer node identity.  Defaults to (in order):
+    /// `NOETL_NODE_ID`, `NODE_NAME`, `K8S_NODE_NAME`, `HOSTNAME`,
+    /// or `"unknown"`.  Consumers refuse to attach when this
+    /// differs from their local node id — POSIX shm is
+    /// per-machine.
+    pub node_id: String,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        let budget_bytes = std::env::var("NOETL_IPC_CACHE_BUDGET_BYTES")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_BUDGET_BYTES);
+        Self {
+            namespace: "noetl".to_string(),
+            budget_bytes,
+            default_lease_seconds: DEFAULT_LEASE_SECONDS,
+            producer: std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string()),
+            node_id: detect_node_id(),
+        }
+    }
+}
+
+fn detect_node_id() -> String {
+    for key in ["NOETL_NODE_ID", "NODE_NAME", "K8S_NODE_NAME", "HOSTNAME"] {
+        if let Ok(v) = std::env::var(key) {
+            let trimmed = v.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+/// Same-node IPC cache for Arrow IPC byte streams.
+///
+/// Wraps POSIX `shm_open` + `mmap` (via the `shared_memory` crate)
+/// to expose a small in-memory key/value store keyed by the cache-
+/// produced `shm_name`.  Producers call [`put_arrow_ipc`][put];
+/// consumers receive the returned [`IpcHint`] over the wire and
+/// call [`get`][get] to materialise the bytes.
+///
+/// Durable payload storage is the authority — this cache is an
+/// **optional** acceleration for colocated producer/consumer pairs.
+/// A consumer that finds the entry expired or evicted falls back
+/// to the durable copy via the normal `result_uri` path.
+///
+/// [put]: ArrowIpcSharedMemoryCache::put_arrow_ipc
+/// [get]: ArrowIpcSharedMemoryCache::get
+pub struct ArrowIpcSharedMemoryCache {
+    config: CacheConfig,
+    /// Tracks live shm regions for budget accounting + eviction.
+    /// Held behind a Mutex because `put_arrow_ipc` / `delete` mutate
+    /// it; the lock window is short (no shm syscalls happen inside
+    /// it).
+    entries: Mutex<HashMap<String, EntryMeta>>,
+}
+
+#[derive(Debug, Clone)]
+struct EntryMeta {
+    byte_length: u64,
+    lease_expires_at: DateTime<Utc>,
+}
+
+impl ArrowIpcSharedMemoryCache {
+    /// Construct a cache with default config (env-derived).
+    pub fn new() -> Self {
+        Self::with_config(CacheConfig::default())
+    }
+
+    /// Construct a cache with an explicit config.
+    pub fn with_config(mut config: CacheConfig) -> Self {
+        // Sanitize + truncate the namespace the same way Python does
+        // so cross-stack names round-trip.  Python's _SAFE_NAME regex
+        // is `[^A-Za-z0-9_]`; we apply the same here.
+        config.namespace = sanitize_namespace(&config.namespace);
+        Self {
+            config,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Total bytes currently allocated across live entries.
+    pub fn used_bytes(&self) -> u64 {
+        self.entries
+            .lock()
+            .expect("cache entries mutex poisoned")
+            .values()
+            .map(|e| e.byte_length)
+            .sum()
+    }
+
+    /// Borrow the active config (read-only).  Useful for tests +
+    /// diagnostics that want to log the effective budget / node id.
+    pub fn config(&self) -> &CacheConfig {
+        &self.config
+    }
+
+    /// Allocate a shared-memory region, copy `payload` into it,
+    /// register it under a lease, and return the [`IpcHint`] a
+    /// consumer needs to attach.
+    ///
+    /// Workflow:
+    ///
+    /// 1. Sweep expired entries (lazy GC piggy-backed on writes).
+    /// 2. Evict-by-lease until `used_bytes + payload.len() <= budget`.
+    /// 3. Compute a fresh shm name from `(namespace, time-stamp,
+    ///    sha256(payload)[:8])`.
+    /// 4. Open + size the shm region; copy bytes.
+    /// 5. Stamp the hint with producer + node id + lease.
+    ///
+    /// Errors:
+    ///
+    /// - `payload` larger than the budget after eviction.
+    /// - shm allocation failure (out-of-space, name collision, etc.).
+    pub fn put_arrow_ipc(
+        &self,
+        payload: &[u8],
+        schema_digest: &str,
+        row_count: Option<u64>,
+        lease_seconds: Option<f64>,
+    ) -> Result<IpcHint> {
+        if schema_digest.is_empty() {
+            return Err(anyhow!("schema_digest is required"));
+        }
+        let payload_len = payload.len() as u64;
+        if payload_len > self.config.budget_bytes {
+            return Err(anyhow!(
+                "payload exceeds IPC cache budget: {} > {}",
+                payload_len,
+                self.config.budget_bytes
+            ));
+        }
+
+        // Lazy GC + budget enforcement BEFORE we open a new region.
+        self.sweep_expired(Utc::now(), 0.0)?;
+        self.evict_until_fits(payload_len)?;
+
+        let name = self.next_shm_name(payload);
+        let mut region = ShmemConf::new()
+            .size(payload.len().max(1))
+            .os_id(&name)
+            .create()
+            .with_context(|| format!("create shm region {}", name))?;
+
+        // SAFETY: `region.as_ptr()` is a valid, exclusive
+        // pointer to a region of `payload.len()` bytes we just
+        // allocated.  We never alias it elsewhere within this scope.
+        unsafe {
+            let dst = region.as_ptr();
+            std::ptr::copy_nonoverlapping(payload.as_ptr(), dst, payload.len());
+        }
+
+        // CRITICAL: release ownership BEFORE dropping the handle.
+        // `shared_memory` defaults `owner = true` on `create()`,
+        // which means `Drop::drop` unlinks the OS region — that
+        // would defeat the whole point of the cache.  We keep the
+        // region alive across the producer call; eviction +
+        // `delete()` are the only paths that unlink.
+        region.set_owner(false);
+        drop(region);
+
+        let lease_seconds = lease_seconds.unwrap_or(self.config.default_lease_seconds);
+        let lease_expires_at = Utc::now() + Duration::milliseconds((lease_seconds * 1000.0) as i64);
+
+        {
+            let mut entries = self.entries.lock().expect("cache entries mutex poisoned");
+            entries.insert(
+                name.clone(),
+                EntryMeta {
+                    byte_length: payload_len,
+                    lease_expires_at,
+                },
+            );
+        }
+
+        let mut hint = IpcHint::new(name, schema_digest, payload_len);
+        hint.row_count = row_count;
+        hint.producer = Some(self.config.producer.clone());
+        hint.node_id = Some(self.config.node_id.clone());
+        hint.lease_expires_at = Some(lease_expires_at);
+        Ok(hint)
+    }
+
+    /// Read the bytes referenced by `hint` out of shared memory.
+    ///
+    /// Returns an error if:
+    /// - the hint has expired,
+    /// - the hint's `node_id` differs from this cache's node id
+    ///   (POSIX shm is per-machine; cross-node attach is a bug),
+    /// - the underlying shm region was evicted or is unreadable.
+    pub fn get(&self, hint: &IpcHint) -> Result<Vec<u8>> {
+        if hint.is_expired(Utc::now()) {
+            return Err(anyhow!("IPC hint expired: {}", hint.shm_name));
+        }
+        if let Some(remote_node) = &hint.node_id {
+            if remote_node != &self.config.node_id {
+                return Err(anyhow!(
+                    "IPC hint belongs to node {}; local node is {}",
+                    remote_node,
+                    self.config.node_id
+                ));
+            }
+        }
+
+        let region = ShmemConf::new()
+            .os_id(&hint.shm_name)
+            .open()
+            .with_context(|| format!("open shm region {}", hint.shm_name))?;
+
+        let length = hint.byte_length as usize;
+        if region.len() < length {
+            return Err(anyhow!(
+                "shm region {} smaller than expected: {} < {}",
+                hint.shm_name,
+                region.len(),
+                length
+            ));
+        }
+
+        // SAFETY: `region.as_ptr()` is a valid, exclusive pointer to
+        // at least `region.len() >= length` bytes; we copy
+        // immediately into an owned `Vec<u8>` and drop the region.
+        let mut buf = vec![0u8; length];
+        unsafe {
+            std::ptr::copy_nonoverlapping(region.as_ptr(), buf.as_mut_ptr(), length);
+        }
+        Ok(buf)
+    }
+
+    /// Delete the shm region referenced by `name`.  Returns `true`
+    /// on successful unlink, `false` when the region wasn't found
+    /// (idempotent).
+    pub fn delete(&self, name: &str) -> Result<bool> {
+        {
+            let mut entries = self.entries.lock().expect("cache entries mutex poisoned");
+            entries.remove(name);
+        }
+        // Open + drop with `set_owner_to_drop(true)` triggers the
+        // unlink path on macOS/Linux.
+        match ShmemConf::new().os_id(name).open() {
+            Ok(mut region) => {
+                region.set_owner(true);
+                drop(region);
+                Ok(true)
+            }
+            Err(shared_memory::ShmemError::MapOpenFailed(_)) => Ok(false),
+            Err(e) => Err(anyhow!("delete shm region {}: {}", name, e)),
+        }
+    }
+
+    /// Reclaim entries whose lease has expired (plus an optional
+    /// grace window).  Returns the count of regions unlinked.
+    pub fn sweep_expired(&self, now: DateTime<Utc>, grace_seconds: f64) -> Result<usize> {
+        let grace = Duration::milliseconds((grace_seconds * 1000.0) as i64);
+        let to_delete: Vec<String> = {
+            let entries = self.entries.lock().expect("cache entries mutex poisoned");
+            entries
+                .iter()
+                .filter(|(_, meta)| now > meta.lease_expires_at + grace)
+                .map(|(name, _)| name.clone())
+                .collect()
+        };
+
+        let mut deleted = 0usize;
+        for name in to_delete {
+            if self.delete(&name)? {
+                deleted += 1;
+            }
+        }
+        Ok(deleted)
+    }
+
+    fn evict_until_fits(&self, incoming_bytes: u64) -> Result<()> {
+        loop {
+            let (would_overflow, oldest_name) = {
+                let entries = self.entries.lock().expect("cache entries mutex poisoned");
+                let used: u64 = entries.values().map(|e| e.byte_length).sum();
+                if used + incoming_bytes <= self.config.budget_bytes {
+                    return Ok(());
+                }
+                if entries.is_empty() {
+                    return Err(anyhow!(
+                        "not enough IPC cache budget after eviction: \
+                         {} (incoming) + {} (used) > {} (budget)",
+                        incoming_bytes,
+                        used,
+                        self.config.budget_bytes
+                    ));
+                }
+                // Pick oldest by lease expiry (matches Python's
+                // `min(_, key=lease_expires_at)`).
+                let oldest = entries
+                    .iter()
+                    .min_by_key(|(_, meta)| meta.lease_expires_at)
+                    .map(|(name, _)| name.clone())
+                    .expect("non-empty checked above");
+                (true, oldest)
+            };
+            if would_overflow {
+                self.delete(&oldest_name)?;
+            }
+        }
+    }
+
+    fn next_shm_name(&self, payload: &[u8]) -> String {
+        // Match the Python format exactly:
+        //   {namespace[:12]}_{stamp:8 hex chars of micros}_{digest:8}
+        let digest_full = Sha256::digest(payload);
+        let digest = hex::encode(&digest_full[..4]); // 8 hex chars
+        let micros = Utc::now().timestamp_micros() as u64;
+        // 8 hex chars of the low bits of micros (matches Python's
+        // `format(int(time*1e6), 'x')[-8:]`).
+        let stamp = format!("{:08x}", micros & 0xFFFF_FFFF);
+        format!("{}_{}_{}", self.config.namespace, stamp, digest)
+    }
+}
+
+impl Default for ArrowIpcSharedMemoryCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn sanitize_namespace(input: &str) -> String {
+    let mut out = String::with_capacity(input.len().min(NAMESPACE_PREFIX_MAX));
+    for ch in input.chars().take(NAMESPACE_PREFIX_MAX * 2) {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+        if out.len() >= NAMESPACE_PREFIX_MAX {
+            break;
+        }
+    }
+    if out.is_empty() {
+        out.push_str("noetl");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_test_namespace() -> String {
+        // Avoid collisions between tests + concurrent runs.
+        let micros = Utc::now().timestamp_micros();
+        format!("t{:x}", micros & 0xFF_FFFF)
+    }
+
+    fn test_cache() -> ArrowIpcSharedMemoryCache {
+        ArrowIpcSharedMemoryCache::with_config(CacheConfig {
+            namespace: unique_test_namespace(),
+            budget_bytes: 4 * 1024,
+            default_lease_seconds: 5.0,
+            producer: "test".to_string(),
+            node_id: "test-node".to_string(),
+        })
+    }
+
+    #[test]
+    fn round_trip_payload_is_byte_for_byte() {
+        let cache = test_cache();
+        let payload = b"hello arrow ipc world";
+        let hint = cache.put_arrow_ipc(payload, "deadbeef", Some(1), None).expect("put");
+        assert_eq!(hint.byte_length, payload.len() as u64);
+        assert_eq!(hint.schema_digest, "deadbeef");
+        assert_eq!(hint.node_id.as_deref(), Some("test-node"));
+        assert_eq!(hint.producer.as_deref(), Some("test"));
+
+        let got = cache.get(&hint).expect("get");
+        assert_eq!(got.as_slice(), payload);
+
+        cache.delete(&hint.shm_name).expect("delete");
+    }
+
+    #[test]
+    fn schema_digest_required() {
+        let cache = test_cache();
+        let err = cache.put_arrow_ipc(b"data", "", None, None).unwrap_err();
+        assert!(err.to_string().contains("schema_digest is required"));
+    }
+
+    #[test]
+    fn payload_over_budget_rejected() {
+        let cache = ArrowIpcSharedMemoryCache::with_config(CacheConfig {
+            namespace: unique_test_namespace(),
+            budget_bytes: 16,
+            default_lease_seconds: 5.0,
+            producer: "test".to_string(),
+            node_id: "test-node".to_string(),
+        });
+        let err = cache.put_arrow_ipc(&[0u8; 32], "feedface", None, None).unwrap_err();
+        assert!(err.to_string().contains("exceeds IPC cache budget"));
+    }
+
+    #[test]
+    fn cross_node_get_is_rejected() {
+        let cache = ArrowIpcSharedMemoryCache::with_config(CacheConfig {
+            namespace: unique_test_namespace(),
+            budget_bytes: 1024,
+            default_lease_seconds: 5.0,
+            producer: "test".to_string(),
+            node_id: "node-a".to_string(),
+        });
+        let payload = b"node-a data";
+        let mut hint = cache.put_arrow_ipc(payload, "deadbeef", None, None).expect("put");
+        hint.node_id = Some("node-b".to_string());
+
+        let err = cache.get(&hint).unwrap_err();
+        assert!(err.to_string().contains("belongs to node"));
+        cache.delete(&hint.shm_name).expect("delete");
+    }
+
+    #[test]
+    fn expired_hint_is_rejected_on_get() {
+        let cache = test_cache();
+        let payload = b"soon to expire";
+        let mut hint = cache
+            .put_arrow_ipc(payload, "deadbeef", None, Some(0.001))
+            .expect("put");
+        // Force expiry by setting the lease in the past.
+        hint.lease_expires_at = Some(Utc::now() - Duration::seconds(1));
+        let err = cache.get(&hint).unwrap_err();
+        assert!(err.to_string().contains("expired"));
+        cache.delete(&hint.shm_name).expect("delete");
+    }
+
+    #[test]
+    fn sweep_expired_reclaims_lease_expired_entries() {
+        let cache = test_cache();
+        let payload = b"some bytes";
+        let hint = cache
+            .put_arrow_ipc(payload, "deadbeef", None, Some(0.001))
+            .expect("put");
+        // Sleep just past the 1ms lease.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let count = cache.sweep_expired(Utc::now(), 0.0).expect("sweep");
+        assert!(count >= 1, "at least one entry must have been swept");
+        // Re-get should fail because the shm region is gone.
+        let err = cache.get(&hint).unwrap_err();
+        assert!(
+            err.to_string().contains("expired") || err.to_string().contains("open shm region"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let cache = test_cache();
+        let hint = cache.put_arrow_ipc(b"x", "deadbeef", None, None).expect("put");
+        assert!(cache.delete(&hint.shm_name).expect("first delete"));
+        // Second delete returns false (region already gone) without
+        // erroring.
+        assert!(!cache.delete(&hint.shm_name).expect("second delete"));
+    }
+
+    #[test]
+    fn evict_until_fits_drops_oldest_to_make_room() {
+        let cache = ArrowIpcSharedMemoryCache::with_config(CacheConfig {
+            namespace: unique_test_namespace(),
+            budget_bytes: 64,
+            default_lease_seconds: 60.0,
+            producer: "test".to_string(),
+            node_id: "test-node".to_string(),
+        });
+        // First put fills ~ half the budget.
+        let first = cache
+            .put_arrow_ipc(&[1u8; 30], "deadbeef", None, None)
+            .expect("first put");
+        // Second put would push the budget over → must evict the first.
+        let second = cache
+            .put_arrow_ipc(&[2u8; 40], "feedface", None, None)
+            .expect("second put");
+        // First entry is gone.
+        let err = cache.get(&first).unwrap_err();
+        assert!(err.to_string().contains("open shm region"), "got: {}", err);
+        // Second entry is still readable.
+        let bytes = cache.get(&second).expect("second get");
+        assert_eq!(bytes, vec![2u8; 40]);
+        cache.delete(&second.shm_name).expect("cleanup");
+    }
+
+    #[test]
+    fn used_bytes_tracks_live_entries() {
+        let cache = test_cache();
+        assert_eq!(cache.used_bytes(), 0);
+        let h1 = cache.put_arrow_ipc(&[0u8; 100], "a", None, None).expect("put");
+        assert_eq!(cache.used_bytes(), 100);
+        let h2 = cache.put_arrow_ipc(&[0u8; 200], "b", None, None).expect("put");
+        assert_eq!(cache.used_bytes(), 300);
+        cache.delete(&h1.shm_name).expect("delete h1");
+        assert_eq!(cache.used_bytes(), 200);
+        cache.delete(&h2.shm_name).expect("delete h2");
+        assert_eq!(cache.used_bytes(), 0);
+    }
+
+    #[test]
+    fn namespace_sanitisation_matches_python() {
+        // Python's `_SAFE_NAME = re.compile(r"[^A-Za-z0-9_]")`
+        // replaces every non-alphanumeric/underscore character with
+        // `_`, then truncates to 12 chars.
+        assert_eq!(sanitize_namespace("ok"), "ok");
+        assert_eq!(sanitize_namespace("noetl-prod"), "noetl_prod");
+        assert_eq!(sanitize_namespace("a/b.c@d#e"), "a_b_c_d_e");
+        // Truncated to 12.
+        assert_eq!(sanitize_namespace("abcdefghijklmnop"), "abcdefghijkl");
+        // Empty falls back to default.
+        assert_eq!(sanitize_namespace(""), "noetl");
+    }
+
+    /// Smoke test: cache name format follows the same shape as
+    /// Python's `{namespace[:12]}_{stamp[:8]}_{digest[:8]}` so an
+    /// observer parsing names off `ls /dev/shm` can tell which
+    /// producer made them.
+    #[test]
+    fn shm_name_shape_matches_python_format() {
+        let cache = ArrowIpcSharedMemoryCache::with_config(CacheConfig {
+            namespace: "tns".to_string(),
+            budget_bytes: 1024,
+            default_lease_seconds: 5.0,
+            producer: "test".to_string(),
+            node_id: "test-node".to_string(),
+        });
+        let hint = cache
+            .put_arrow_ipc(b"name shape test", "deadbeef", None, None)
+            .expect("put");
+        let parts: Vec<&str> = hint.shm_name.splitn(3, '_').collect();
+        assert_eq!(parts.len(), 3, "expected three `_`-joined segments");
+        assert_eq!(parts[0], "tns");
+        assert_eq!(parts[1].len(), 8, "stamp segment is 8 hex chars");
+        assert_eq!(parts[2].len(), 8, "digest segment is 8 hex chars");
+        assert!(parts[1].chars().all(|c| c.is_ascii_hexdigit()), "stamp must be hex");
+        assert!(parts[2].chars().all(|c| c.is_ascii_hexdigit()), "digest must be hex");
+        cache.delete(&hint.shm_name).expect("delete");
+    }
+}

--- a/arrow-cache/src/hint.rs
+++ b/arrow-cache/src/hint.rs
@@ -1,0 +1,219 @@
+//! [`IpcHint`] — the wire-format handle the cache produces.
+//!
+//! Mirrors the Python `IpcHint` Pydantic model in
+//! `noetl/core/storage/models.py` 1:1 so a hint produced by either
+//! stack deserialises cleanly on the other.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Best-effort same-node shared-memory hint for a durable payload
+/// reference.
+///
+/// JSON shape (matches Python's `IpcHint`):
+///
+/// ```json
+/// {
+///   "kind": "arrow_ipc",
+///   "shm_name": "noetl_abc12345_def67890",
+///   "schema_digest": "8badf00d",
+///   "byte_length": 4096,
+///   "row_count": 128,
+///   "producer": "noetl-worker-rust-7",
+///   "node_id": "kind-noetl",
+///   "lease_expires_at": "2026-05-31T08:00:00Z",
+///   "media_type": "application/vnd.apache.arrow.stream"
+/// }
+/// ```
+///
+/// `kind` is fixed to `"arrow_ipc"` for forward compatibility — if
+/// future cache variants surface (e.g. `"arrow_file"`), they get
+/// their own dispatched type.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IpcHint {
+    /// Discriminator — always `"arrow_ipc"`.  Defaulted so
+    /// pre-discriminator JSON deserialises cleanly.
+    #[serde(default = "default_kind")]
+    pub kind: String,
+
+    /// Shared-memory region name as it appears in `/dev/shm` on
+    /// Linux.  Producer fills this from
+    /// [`ArrowIpcSharedMemoryCache::put_arrow_ipc`]; consumer feeds
+    /// it back into `get`.
+    pub shm_name: String,
+
+    /// Schema fingerprint — 8 hex chars of the Arrow schema's
+    /// SHA-256.  Lets consumers cheaply detect schema drift before
+    /// attaching the shared-memory region.
+    pub schema_digest: String,
+
+    /// Size of the payload bytes in the shared-memory region.
+    pub byte_length: u64,
+
+    /// Optional row count for diagnostic + telemetry use.  The
+    /// cache itself doesn't read or validate the bytes — this is
+    /// metadata only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub row_count: Option<u64>,
+
+    /// Identity of the process that produced the entry.  Useful
+    /// for cross-component correlation in distributed traces;
+    /// purely informational on this side of the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer: Option<String>,
+
+    /// Producer node identity.  Consumers MUST skip IPC attach
+    /// when this differs from the local node — POSIX shm is
+    /// per-machine, so cross-node attach would either silently
+    /// return the wrong bytes (if names collide) or fail with
+    /// `ENOENT`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+
+    /// UTC instant after which the entry MAY be reclaimed by the
+    /// producer's eviction sweep.  Consumers SHOULD attempt the
+    /// read promptly; `None` means "no lease, eviction-only" (the
+    /// producer manages lifetime by hand).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at: Option<DateTime<Utc>>,
+
+    /// Media type of the bytes in the region.  Defaults to the
+    /// Arrow IPC stream MIME so consumers without a hint can still
+    /// pick the right decoder.
+    #[serde(default = "default_media_type")]
+    pub media_type: String,
+}
+
+impl IpcHint {
+    /// Construct a fresh hint with defaults for `kind` +
+    /// `media_type`.  Producers prefer this over the struct
+    /// literal so the discriminator + media type stay in sync.
+    pub fn new(shm_name: impl Into<String>, schema_digest: impl Into<String>, byte_length: u64) -> Self {
+        Self {
+            kind: default_kind(),
+            shm_name: shm_name.into(),
+            schema_digest: schema_digest.into(),
+            byte_length,
+            row_count: None,
+            producer: None,
+            node_id: None,
+            lease_expires_at: None,
+            media_type: default_media_type(),
+        }
+    }
+
+    /// Returns true if `lease_expires_at` is set AND `now` is past
+    /// it.  Hints without a lease never expire (the producer
+    /// manages lifetime out-of-band).
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        match self.lease_expires_at {
+            Some(expires) => now > expires,
+            None => false,
+        }
+    }
+}
+
+fn default_kind() -> String {
+    "arrow_ipc".to_string()
+}
+
+fn default_media_type() -> String {
+    "application/vnd.apache.arrow.stream".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Python `IpcHint` JSON deserialises cleanly into the Rust
+    /// struct — the cross-stack handoff is the load-bearing
+    /// contract for R-2.1.
+    #[test]
+    fn deserialises_python_ipc_hint_json() {
+        let wire = serde_json::json!({
+            "kind": "arrow_ipc",
+            "shm_name": "noetl_abc12345_def67890",
+            "schema_digest": "8badf00d",
+            "byte_length": 4096,
+            "row_count": 128,
+            "producer": "noetl-worker-rust-7",
+            "node_id": "kind-noetl",
+            "lease_expires_at": "2026-05-31T08:00:00Z",
+            "media_type": "application/vnd.apache.arrow.stream"
+        });
+        let hint: IpcHint = serde_json::from_value(wire).unwrap();
+        assert_eq!(hint.kind, "arrow_ipc");
+        assert_eq!(hint.shm_name, "noetl_abc12345_def67890");
+        assert_eq!(hint.schema_digest, "8badf00d");
+        assert_eq!(hint.byte_length, 4096);
+        assert_eq!(hint.row_count, Some(128));
+        assert_eq!(hint.producer.as_deref(), Some("noetl-worker-rust-7"));
+        assert_eq!(hint.node_id.as_deref(), Some("kind-noetl"));
+        assert_eq!(hint.media_type, "application/vnd.apache.arrow.stream");
+        assert!(hint.lease_expires_at.is_some());
+    }
+
+    /// Older Python clients (or future minimal Rust callers) send
+    /// only the required fields — the `kind` + `media_type`
+    /// defaults must kick in.
+    #[test]
+    fn deserialises_minimal_ipc_hint_json() {
+        let wire = serde_json::json!({
+            "shm_name": "noetl_test",
+            "schema_digest": "00000000",
+            "byte_length": 0,
+        });
+        let hint: IpcHint = serde_json::from_value(wire).unwrap();
+        assert_eq!(hint.kind, "arrow_ipc");
+        assert_eq!(hint.media_type, "application/vnd.apache.arrow.stream");
+        assert!(hint.row_count.is_none());
+        assert!(hint.producer.is_none());
+        assert!(hint.node_id.is_none());
+        assert!(hint.lease_expires_at.is_none());
+    }
+
+    /// `IpcHint::new` returns a hint with sensible defaults.
+    #[test]
+    fn new_uses_canonical_defaults() {
+        let hint = IpcHint::new("noetl_x", "deadbeef", 1024);
+        assert_eq!(hint.kind, "arrow_ipc");
+        assert_eq!(hint.media_type, "application/vnd.apache.arrow.stream");
+        assert!(hint.lease_expires_at.is_none());
+    }
+
+    /// `is_expired` honors the lease.
+    #[test]
+    fn is_expired_respects_lease() {
+        let now = Utc::now();
+        let mut hint = IpcHint::new("noetl_x", "deadbeef", 1024);
+
+        // No lease → never expired.
+        assert!(!hint.is_expired(now));
+
+        // Lease in the future → not expired.
+        hint.lease_expires_at = Some(now + chrono::Duration::seconds(60));
+        assert!(!hint.is_expired(now));
+
+        // Lease in the past → expired.
+        hint.lease_expires_at = Some(now - chrono::Duration::seconds(1));
+        assert!(hint.is_expired(now));
+    }
+
+    /// JSON shape — kind defaults, optional fields omitted when None.
+    #[test]
+    fn serialises_to_python_compatible_shape() {
+        let hint = IpcHint::new("noetl_x", "deadbeef", 1024);
+        let json = serde_json::to_value(&hint).unwrap();
+        // Required top-level fields present.
+        assert_eq!(json["kind"], "arrow_ipc");
+        assert_eq!(json["shm_name"], "noetl_x");
+        assert_eq!(json["schema_digest"], "deadbeef");
+        assert_eq!(json["byte_length"], 1024);
+        assert_eq!(json["media_type"], "application/vnd.apache.arrow.stream");
+        // None fields omitted from JSON.
+        assert!(json.get("row_count").is_none());
+        assert!(json.get("producer").is_none());
+        assert!(json.get("node_id").is_none());
+        assert!(json.get("lease_expires_at").is_none());
+    }
+}

--- a/arrow-cache/src/lib.rs
+++ b/arrow-cache/src/lib.rs
@@ -1,0 +1,62 @@
+//! Arrow IPC shared-memory cache — same-node zero-copy data plane.
+//!
+//! Rust mirror of the Python
+//! [`ArrowIpcSharedMemoryCache`][py-cache] in
+//! `noetl/core/storage/ipc_cache.py`.  Both implementations use POSIX
+//! `shm_open` + `mmap` under the hood (Python via
+//! `multiprocessing.shared_memory.SharedMemory`, Rust via the
+//! [`shared_memory`](https://docs.rs/shared_memory) crate), so a
+//! payload written by either side is readable by the other AS LONG AS
+//! they share the same node identity (the `node_id` field on the
+//! produced [`IpcHint`]).
+//!
+//! Per Appendix H of the global hybrid cloud blueprint — R-2.1 of the
+//! Rust migration roadmap.  See
+//! [executor-crate-architecture][cli-wiki] on the noetl/cli wiki for
+//! the wider architectural context.
+//!
+//! ## Contract with the Python side
+//!
+//! The Python `ArrowIpcSharedMemoryCache` produces `IpcHint` JSON
+//! payloads with these fields (`noetl/core/storage/models.py`):
+//!
+//! - `kind` (always `"arrow_ipc"`)
+//! - `shm_name`
+//! - `schema_digest`
+//! - `byte_length`
+//! - `row_count` (optional)
+//! - `producer` (optional)
+//! - `node_id` (optional)
+//! - `lease_expires_at` (optional, UTC ISO 8601)
+//! - `media_type` (defaults to `"application/vnd.apache.arrow.stream"`)
+//!
+//! [`IpcHint`] in this crate serialises to the exact same JSON shape.
+//!
+//! ## Lease + eviction
+//!
+//! Entries carry a lease expiry.  [`ArrowIpcSharedMemoryCache::put_arrow_ipc`]
+//! calls [`ArrowIpcSharedMemoryCache::sweep_expired`] + budget-based
+//! eviction before allocating, so under steady-state load the cache
+//! self-trims to fit `budget_bytes` (default 256 MB, configurable via
+//! the `NOETL_IPC_CACHE_BUDGET_BYTES` env var on construction).
+//!
+//! ## Why a separate crate
+//!
+//! The shared-memory dep (`shared_memory`) brings POSIX-specific
+//! crates that don't belong in `noetl-tools` (which builds for many
+//! contexts including the worker binary).  The cache is also a
+//! standalone concept — both the CLI's local runtime and the worker's
+//! NATS dispatch loop can use it to publish IPC hints for the
+//! consuming step.  Keeping it as a sibling crate to `noetl-executor`
+//! mirrors the layout of the broader Rust workspace.
+//!
+//! [py-cache]: https://github.com/noetl/noetl/blob/main/noetl/core/storage/ipc_cache.py
+//! [cli-wiki]: https://github.com/noetl/cli/wiki/executor-crate-architecture
+
+#![warn(missing_docs)]
+
+mod cache;
+mod hint;
+
+pub use cache::{ArrowIpcSharedMemoryCache, CacheConfig};
+pub use hint::IpcHint;


### PR DESCRIPTION
## Summary

**R-2.1 of the Rust migration roadmap** (Appendix H of the global hybrid cloud blueprint).  Rust mirror of Python's [\`ArrowIpcSharedMemoryCache\`](https://github.com/noetl/noetl/blob/main/noetl/core/storage/ipc_cache.py) in \`noetl/core/storage/ipc_cache.py\` — same-node zero-copy IPC for the NoETL columnar data plane.

A small in-process cache keyed by an \`IpcHint\` token.  Producers push Arrow IPC byte streams into shared memory; colocated consumers read them back without going through the durable storage path.  The hint is JSON-serialisable and crosses process boundaries through any transport; the bytes themselves stay on the same machine.

## Cross-stack compatibility (the load-bearing contract)

- \`IpcHint\` JSON shape matches Python's Pydantic model 1:1.
- POSIX shm primitive on both sides — Python uses \`multiprocessing.shared_memory.SharedMemory\`, Rust uses the \`shared_memory\` crate (same \`shm_open\` + \`mmap\` syscalls).  A region created by either stack is attachable by the other on the same node.
- \`shm_name\` format: \`{namespace[:12]}_{stamp:8-hex}_{digest:8-hex}\` matches Python's format exactly.
- Namespace sanitisation: Python's \`_SAFE_NAME = re.compile(r\"[^A-Za-z0-9_]\")\` rule mirrored byte-for-byte.

## Public surface

\`ArrowIpcSharedMemoryCache\` with:

- \`new()\` / \`with_config(CacheConfig)\` — defaults sourced from the same env vars Python reads (\`NOETL_IPC_CACHE_BUDGET_BYTES\`, \`NOETL_NODE_ID\` / \`NODE_NAME\` / \`K8S_NODE_NAME\` / \`HOSTNAME\`).
- \`put_arrow_ipc(payload, schema_digest, row_count, lease_seconds)\` → \`IpcHint\`.
- \`get(&IpcHint)\` → \`Vec<u8>\` (expiry + cross-node checks).
- \`delete(name)\` — unlinks the shm region; idempotent.
- \`sweep_expired(now, grace_seconds)\` — lazy GC piggy-backed on \`put\`.
- \`used_bytes()\` — live-byte accounting.

## Where this fits

- **Producer**: a \`noetl-tools\` step that produces a large Arrow RecordBatch (DuckDB, Postgres, HTTP CSV, etc.) calls \`noetl_tools::arrow_codec::encode_record_batch\` + this cache.  The returned \`IpcHint\` rides the event log alongside the durable \`result_uri\`.
- **Consumer**: a colocated step reads the hint, calls \`cache.get(&hint)\`, decodes via \`noetl_tools::arrow_codec::decode_record_batches\`.  No network round-trip, no disk I/O.

The Arrow Flight gRPC endpoint on noetl-worker (R-2.2) is the follow-up that exposes the same bytes over network when producer/consumer aren't colocated.

## Tests

**16 unit tests pass** + clippy clean with \`-D warnings\` + cargo fmt clean:

- \`IpcHint\` Python-compatible JSON round-trip (full + minimal shape).
- \`IpcHint::new\` defaults + \`is_expired\` semantics.
- Cache: round-trip byte-for-byte, schema-digest validation, budget enforcement, cross-node rejection, expired-hint rejection, lazy sweep, idempotent delete, evict-until-fits drops the oldest by lease, \`used_bytes\` accounting, namespace sanitisation matches Python, shm-name format matches Python.

## Workspace layout after this PR

\`\`\`
repos/cli/
├── Cargo.toml          # noetl bin (root)
├── executor/           # noetl-executor crate (R-1.1)
└── arrow-cache/        # noetl-arrow-cache crate (this PR, R-2.1)
\`\`\`

## Versioning

New crate at \`0.1.0\`; the workspace's existing crates (noetl bin, noetl-executor) are untouched.  Semantic-release will not bump either of them.  The new crate publishes independently on the next release cycle.

Refs [noetl/ai-meta#30](https://github.com/noetl/ai-meta/issues/30) — Appendix H Rust migration umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)