### PR TITLE
feat(arrow-flight-client): noetl-arrow-flight-client crate (R-2.3 Phase B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,15 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,163 +127,400 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 53.4.1",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-cast 53.4.1",
+ "arrow-csv",
+ "arrow-data 53.4.1",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord 53.4.1",
+ "arrow-row 53.4.1",
+ "arrow-schema 53.4.1",
+ "arrow-select 53.4.1",
+ "arrow-string 53.4.1",
+]
+
+[[package]]
+name = "arrow"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+dependencies = [
+ "arrow-arith 54.2.1",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.2.1",
+ "arrow-data 54.3.1",
+ "arrow-ord 54.2.1",
+ "arrow-row 54.2.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1",
+ "arrow-string 54.2.1",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
  "chrono",
- "num-traits",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "num",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
  "chrono",
  "half",
- "hashbrown 0.17.1",
- "num-complex",
- "num-integer",
- "num-traits",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
- "num-traits",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "arrow-select 53.4.1",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1",
  "atoi",
  "base64",
  "chrono",
  "comfy-table",
  "half",
  "lexical-core",
- "num-traits",
+ "num",
  "ryu",
 ]
 
 [[package]]
-name = "arrow-data"
-version = "58.3.0"
+name = "arrow-csv"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "30dac4d23ac769300349197b845e0fd18c7f9f15d260d4659ae6b5a9ca06f586"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-cast 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+dependencies = [
+ "arrow-buffer 53.4.1",
+ "arrow-schema 53.4.1",
  "half",
- "num-integer",
- "num-traits",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
+dependencies = [
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e3a40b6ef36f4c17d1fae5af3438c3d6c660401f9ac8a4d921c27d368b8dee"
+dependencies = [
+ "arrow-arith 53.4.1",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-cast 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-ipc",
+ "arrow-ord 53.4.1",
+ "arrow-row 53.4.1",
+ "arrow-schema 53.4.1",
+ "arrow-select 53.4.1",
+ "arrow-string 53.4.1",
+ "base64",
+ "bytes",
+ "futures",
+ "once_cell",
+ "paste",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
+dependencies = [
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-cast 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdec0024749fc0d95e025c0b0266d78613727b3b3a5d4cf8ea47eb6d38afdd1"
+dependencies = [
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-cast 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "arrow-select 53.4.1",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "ahash 0.8.12",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "half",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+
+[[package]]
+name = "arrow-schema"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "num",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "58.3.0"
+version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.1",
+ "arrow-buffer 53.4.1",
+ "arrow-data 53.4.1",
+ "arrow-schema 53.4.1",
+ "arrow-select 53.4.1",
  "memchr",
- "num-traits",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1",
+ "memchr",
+ "num",
  "regex",
  "regex-syntax",
 ]
@@ -356,6 +590,53 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backoff"
@@ -538,16 +819,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -578,7 +860,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -608,7 +890,6 @@ version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
- "crossterm 0.28.1",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -756,19 +1037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.1",
- "crossterm_winapi",
- "parking_lot",
- "rustix 0.38.44",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +1068,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -879,17 +1168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -975,20 +1253,21 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
-version = "1.10503.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
+checksum = "49ac283b6621e3becf8014d1efa655522794075834c72f744573debef9c9f6c8"
 dependencies = [
- "arrow",
+ "arrow 54.2.1",
  "cast",
- "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libduckdb-sys",
+ "memchr",
  "num-integer",
  "rust_decimal",
- "strum 0.27.2",
+ "smallvec",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -1113,6 +1392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,7 +1409,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -1158,6 +1446,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1179,6 +1468,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1315,7 +1615,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1345,6 +1645,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1362,11 +1671,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1392,6 +1701,12 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1508,6 +1823,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1583,7 +1899,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1726,6 +2042,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1911,7 +2237,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -2053,19 +2379,18 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10503.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
+checksum = "12cac9d03484c43fefac8b2066a253c9b0b3b0cd02cbe02a9ea2312f7e382618"
 dependencies = [
+ "autocfg",
  "cc",
  "flate2",
  "pkg-config",
- "reqwest",
  "serde",
  "serde_json",
  "tar",
  "vcpkg",
- "zip",
 ]
 
 [[package]]
@@ -2082,12 +2407,6 @@ checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2139,6 +2458,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -2262,7 +2587,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
- "crossterm 0.27.0",
+ "crossterm",
  "dirs 5.0.1",
  "dotenvy",
  "duckdb",
@@ -2300,6 +2625,22 @@ dependencies = [
  "shared_memory",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "noetl-arrow-flight-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrow 53.4.1",
+ "arrow-flight",
+ "futures",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
 ]
 
@@ -2369,6 +2710,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2748,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2706,6 +3083,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,7 +3147,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2775,7 +3184,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2892,7 +3301,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cassowary",
  "compact_str",
- "crossterm 0.27.0",
+ "crossterm",
  "itertools 0.12.1",
  "lru",
  "paste",
@@ -3000,9 +3409,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3022,7 +3429,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3139,16 +3546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
@@ -3160,7 +3563,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3424,7 +3827,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3575,6 +3978,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -3630,6 +4043,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -3638,21 +4060,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3661,13 +4074,14 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.117",
 ]
 
@@ -3759,7 +4173,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3864,7 +4278,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3900,7 +4314,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.10.1",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-util",
  "whoami",
@@ -3913,6 +4327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3945,7 +4370,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3958,6 +4383,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3991,7 +4466,7 @@ dependencies = [
  "http-body",
  "mime",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4352,7 +4827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4365,7 +4840,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4593,15 +5068,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4871,7 +5337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4882,8 +5348,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
- "indexmap",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4914,7 +5380,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4933,7 +5399,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4965,7 +5431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -5072,39 +5538,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@
 # - `arrow-cache` — Rust mirror of Python's
 #   `ArrowIpcSharedMemoryCache`.  Same-node zero-copy IPC for the
 #   columnar data plane.  R-2.1 in the Rust migration roadmap.
-members = ["executor", "arrow-cache"]
+# - `arrow-flight-client` — Rust client for the noetl-server's
+#   Arrow Flight `do_get` endpoint.  R-2.3 Phase B; pairs with the
+#   Python server in noetl/noetl#643.
+members = ["executor", "arrow-cache", "arrow-flight-client"]
 
 [package]
 name = "noetl"

--- a/arrow-flight-client/Cargo.toml
+++ b/arrow-flight-client/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "noetl-arrow-flight-client"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/noetl/cli"
+homepage = "https://noetl.io"
+description = "NoETL Arrow Flight client — Rust consumer for the noetl-server's /api/result Flight gRPC endpoint (R-2.3 Phase B)"
+keywords = ["arrow", "flight", "grpc", "noetl"]
+categories = ["api-bindings", "data-structures"]
+readme = "README.md"
+
+[dependencies]
+# Arrow Flight gRPC client.  Same version family the workspace's
+# sibling crate `noetl-arrow-cache` uses for the on-the-wire Arrow IPC
+# decoder, so RecordBatch types interop without conversion.
+arrow-flight = "53"
+arrow = "53"
+
+# Async runtime + tonic transport.  arrow-flight 53 builds on
+# tonic 0.12 + tokio; pin them explicitly so the compile graph
+# is stable.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tonic = "0.12"
+futures = "0.3"
+
+# Error handling — Anyhow for the public API + thiserror for typed
+# errors that callers can match on.
+anyhow = "1.0"
+thiserror = "2.0"
+
+# Tracing for the resolve span (per agents/rules/observability.md
+# Principle 1 — every boundary call ships a span).
+tracing = "0.1"
+
+# JSON conversion for the row-shape convenience helper.
+serde_json = "1.0"
+
+[dev-dependencies]
+# Spinning up an in-test Flight server requires the full server side
+# of arrow-flight (the encoder/server stubs).  tokio_stream wraps the
+# TcpListener for use with `Server::serve_with_incoming_shutdown`.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
+futures = "0.3"

--- a/arrow-flight-client/README.md
+++ b/arrow-flight-client/README.md
@@ -1,0 +1,62 @@
+# noetl-arrow-flight-client
+
+Rust client for the [NoETL server's Arrow Flight `do_get` endpoint][server-flight]
+(R-2.3 Phase A).  Fetches tabular result-store payloads as Arrow IPC
+streams over gRPC, returning typed `RecordBatch`es with zero JSON
+serialisation overhead in the consumer leg.
+
+See [Appendix H §H.4 (data plane)][appendix-h] for the architectural
+context and the [Arrow Flight Result Fetch wiki page][wiki] for the
+wire protocol contract.
+
+## Use
+
+```rust
+use noetl_arrow_flight_client::FlightResolver;
+
+let resolver = FlightResolver::connect("grpc://noetl.noetl.svc.cluster.local:8083").await?;
+let batches = resolver
+    .resolve("noetl://execution/12345/result/big_select/abcd1234")
+    .await?;
+```
+
+The returned `Vec<RecordBatch>` can be inspected via the `arrow`
+crate's `RecordBatch::column` / `RecordBatch::schema` accessors, or
+flattened to JSON via the [`resolve_rows`][resolve-rows] convenience
+helper.
+
+## Why a separate crate
+
+The Flight client is reusable across multiple Rust consumers:
+
+- The **noetl-worker** that needs to fetch a cross-node tabular
+  result before a downstream step runs.
+- The **Rust noetl-server** (under `repos/server`) once it gains a
+  result-store backend and needs to proxy fetches.
+- The **CLI** tree walker (under `noetl-executor`) for local-mode
+  consumers that share the same wire format.
+
+Keeping the client in its own crate avoids coupling these consumers
+to each other's Cargo build graphs.
+
+## R-2.3 phase coordination
+
+| Phase | Status |
+|-------|--------|
+| A — Python server `do_get` endpoint | ✅ landed (noetl/noetl#643) |
+| **B — this crate** | ✅ shipping (skeleton); worker callsite deferred to a follow-up once a real consumer surfaces |
+| C — `FlightInfo` discovery + mTLS | Planned |
+
+## See also
+
+- [`noetl-arrow-cache`](../arrow-cache) — same workspace's sibling
+  crate for the same-node shared-memory cache that consumers can
+  attach to when the Flight server's `IpcHint` indicates a colocated
+  shm region exists.
+- [`noetl-tools::arrow_codec`](https://github.com/noetl/tools/blob/main/src/arrow_codec.rs)
+  — the encoder the server uses to produce these IPC streams.
+
+[server-flight]: https://github.com/noetl/noetl/blob/main/noetl/server/api/result/flight_server.py
+[appendix-h]: https://noetl.dev/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint#h4-data-plane
+[wiki]: https://github.com/noetl/noetl/wiki/arrow_flight_result_fetch
+[resolve-rows]: https://docs.rs/noetl-arrow-flight-client/latest/noetl_arrow_flight_client/struct.FlightResolver.html#method.resolve_rows

--- a/arrow-flight-client/src/lib.rs
+++ b/arrow-flight-client/src/lib.rs
@@ -1,0 +1,328 @@
+//! NoETL Arrow Flight client.
+//!
+//! Mirrors the Python recipe documented on the noetl wiki page
+//! [`arrow_flight_result_fetch`][wiki]:
+//!
+//! ```text
+//! ticket = noetl://execution/<eid>/result/<step>/<id>
+//!     do_get(ticket) → Arrow IPC stream → RecordBatch
+//! ```
+//!
+//! The server side (R-2.3 Phase A, noetl/noetl#643) treats the
+//! ticket bytes as the URI, resolves via `default_store.resolve(ref)`,
+//! encodes via `rows_to_arrow_ipc`, and streams `FlightData` back.
+//! This crate is the Rust consumer.
+//!
+//! ## Boundary discipline
+//!
+//! Per [`agents/rules/execution-model.md`][execution-model] the
+//! resolver is a thin RPC client; it does not cache, scrub, or
+//! validate the payload — those happen server-side.  The credential
+//! scrubbing the server applies to the bytes before encoding
+//! round-trips through this client unchanged.
+//!
+//! ## R-2.3 phase scope
+//!
+//! Phase B (this crate) ships the standalone client.  Wiring it into
+//! a concrete consumer (the noetl-worker for cross-node tabular
+//! reads, the Rust noetl-server once it gains a result-store
+//! backend, the CLI tree walker for local-mode consumers) is
+//! deferred until a real caller surfaces.  Keeping the client in
+//! its own crate avoids coupling those consumers to each other's
+//! Cargo build graphs.
+//!
+//! [wiki]: https://github.com/noetl/noetl/wiki/arrow_flight_result_fetch
+//! [execution-model]: https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arrow::array::RecordBatch;
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::Ticket;
+use futures::TryStreamExt;
+use thiserror::Error;
+use tonic::transport::{Channel, Endpoint};
+
+/// Typed error variants for `resolve()` failures.  Callers usually
+/// match on the variant to decide between fall-back paths (HTTP
+/// `/api/result/resolve` for `NonTabular`, a hard error for the
+/// rest).
+#[derive(Debug, Error)]
+pub enum FlightError {
+    /// gRPC channel failed to connect or the request itself errored.
+    #[error("gRPC transport error: {0}")]
+    Transport(String),
+
+    /// Server returned a `FlightUnavailableError` — typically means
+    /// the referenced result is non-tabular and the consumer should
+    /// fall back to the HTTP `/api/result/resolve` endpoint.
+    #[error("server unavailable for ref {ref_uri}: {message}")]
+    NonTabular { ref_uri: String, message: String },
+
+    /// Server returned some other typed Flight error.
+    #[error("server error: {0}")]
+    Server(String),
+}
+
+/// Thin wrapper around `arrow_flight::FlightServiceClient` that
+/// turns ref URIs into `RecordBatch` streams.
+///
+/// The resolver owns a long-lived gRPC channel; construct one per
+/// (process, server-endpoint) pair and reuse it across `resolve`
+/// calls.
+#[derive(Clone)]
+pub struct FlightResolver {
+    client: FlightServiceClient<Channel>,
+    endpoint: String,
+}
+
+impl FlightResolver {
+    /// Connect to the noetl-server's Flight endpoint.  `endpoint`
+    /// must be a gRPC URL such as `grpc://localhost:8083` or
+    /// `grpc://noetl.noetl.svc.cluster.local:8083`.
+    ///
+    /// Honors a 10s connect timeout — Flight is on the cluster
+    /// network and a slow connect almost always means the server
+    /// pod is unhealthy; failing fast lets the caller switch to the
+    /// HTTP fallback or surface a clearer error.
+    pub async fn connect(endpoint: impl Into<String>) -> Result<Self> {
+        let endpoint_str = endpoint.into();
+        let channel = Endpoint::from_shared(endpoint_str.clone())
+            .with_context(|| format!("parse Flight endpoint {endpoint_str}"))?
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .connect()
+            .await
+            .with_context(|| format!("connect to Flight endpoint {endpoint_str}"))?;
+        let client = FlightServiceClient::new(channel);
+        Ok(Self {
+            client,
+            endpoint: endpoint_str,
+        })
+    }
+
+    /// Endpoint this resolver is connected to.  Useful for logging.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Submit `ref_uri` as a Flight Ticket and collect the streamed
+    /// RecordBatches.  Each batch carries one chunk of rows; for
+    /// small results (Phase A's `rows_to_arrow_ipc` produces a
+    /// single batch) the returned Vec has length 1.
+    ///
+    /// Returns:
+    ///
+    /// - `Ok(batches)` on success (may be empty if the server
+    ///   streamed zero batches).
+    /// - `Err(FlightError::NonTabular { .. })` when the server
+    ///   returned a `FlightUnavailableError` — typically means the
+    ///   ref points at non-tabular data and the consumer should
+    ///   fall back to HTTP `/api/result/resolve`.
+    /// - `Err(FlightError::Server { .. })` for other server-side
+    ///   errors.
+    /// - `Err(FlightError::Transport { .. })` for transport-level
+    ///   failures (network, gRPC framing, etc.).
+    ///
+    /// Per `observability.md` Principle 1, the call is wrapped in a
+    /// `flight.resolve` span carrying `endpoint` + `ref_uri`.
+    pub async fn resolve(&self, ref_uri: &str) -> Result<Vec<RecordBatch>, FlightError> {
+        let span = tracing::info_span!(
+            "flight.resolve",
+            endpoint = %self.endpoint,
+            ref_uri = %ref_uri,
+        );
+        let _enter = span.enter();
+
+        let ticket = Ticket {
+            ticket: ref_uri.as_bytes().to_vec().into(),
+        };
+
+        let mut client = self.client.clone();
+        let stream = match client.do_get(ticket).await {
+            Ok(response) => response.into_inner(),
+            Err(status) => {
+                return Err(classify_status(ref_uri, &status));
+            }
+        };
+
+        // Wrap the raw FlightData stream in the high-level
+        // RecordBatchStream decoder; collect into a Vec.
+        let mut batches: Vec<RecordBatch> = Vec::new();
+        let mut record_stream =
+            FlightRecordBatchStream::new_from_flight_data(stream.map_err(arrow_flight::error::FlightError::Tonic));
+        loop {
+            match record_stream.try_next().await {
+                Ok(Some(batch)) => batches.push(batch),
+                Ok(None) => break,
+                Err(arrow_flight::error::FlightError::Tonic(status)) => {
+                    return Err(classify_status(ref_uri, &status));
+                }
+                Err(other) => {
+                    return Err(FlightError::Server(format!("decode error for ref {ref_uri}: {other}")));
+                }
+            }
+        }
+        tracing::info!(
+            endpoint = %self.endpoint,
+            ref_uri = %ref_uri,
+            batches = batches.len(),
+            total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            "flight.resolve completed",
+        );
+        Ok(batches)
+    }
+
+    /// Convenience: resolve the ref, then flatten the batches into a
+    /// `Vec<serde_json::Value>` of row objects.  Mirrors the Python
+    /// `client.do_get(ticket).read_all().to_pylist()` recipe.
+    ///
+    /// Use this when the caller wants JSON-shaped rows; prefer
+    /// [`resolve`] when columnar access is enough (`RecordBatch`
+    /// avoids the per-row hashmap allocation).
+    pub async fn resolve_rows(&self, ref_uri: &str) -> Result<Vec<serde_json::Value>, FlightError> {
+        let batches = self.resolve(ref_uri).await?;
+        let mut rows: Vec<serde_json::Value> = Vec::new();
+        for batch in &batches {
+            extend_rows_from_batch(&mut rows, batch)
+                .map_err(|e| FlightError::Server(format!("row materialisation error for ref {ref_uri}: {e}")))?;
+        }
+        Ok(rows)
+    }
+}
+
+/// Map a tonic `Status` into the typed [`FlightError`] variants.
+fn classify_status(ref_uri: &str, status: &tonic::Status) -> FlightError {
+    let code = status.code();
+    let message = status.message().to_string();
+    // Server-side `FlightUnavailableError` lands as gRPC code
+    // UNAVAILABLE; treat it as the "non-tabular fall back to HTTP"
+    // signal documented by Phase A.
+    if code == tonic::Code::Unavailable {
+        return FlightError::NonTabular {
+            ref_uri: ref_uri.to_string(),
+            message,
+        };
+    }
+    if matches!(
+        code,
+        tonic::Code::Unknown
+            | tonic::Code::Internal
+            | tonic::Code::FailedPrecondition
+            | tonic::Code::Unimplemented
+            | tonic::Code::InvalidArgument
+            | tonic::Code::NotFound
+            | tonic::Code::PermissionDenied
+            | tonic::Code::Unauthenticated
+    ) {
+        return FlightError::Server(format!("code={:?} message={} ref={}", code, message, ref_uri));
+    }
+    FlightError::Transport(format!("code={:?} message={} ref={}", code, message, ref_uri))
+}
+
+/// Walk a RecordBatch row-by-row, appending JSON-shaped objects to
+/// `out`.  Each column converts via Arrow's native -> JSON path.
+///
+/// `#[allow(clippy::needless_range_loop)]` — we read a typed array
+/// at `row_idx` AND write `row_objects[row_idx]` in the same step,
+/// so the suggested `iter().enumerate()` over `row_objects` would
+/// force a duplicate column traversal.  Index loops are the right
+/// shape here.
+#[allow(clippy::needless_range_loop)]
+fn extend_rows_from_batch(out: &mut Vec<serde_json::Value>, batch: &RecordBatch) -> Result<()> {
+    use arrow::array::*;
+    use arrow::datatypes::DataType;
+
+    let num_rows = batch.num_rows();
+    let schema = batch.schema();
+
+    // Pre-allocate empty row objects so we can fill columns in
+    // place; one column-pass per field is friendlier to the cache
+    // than per-row dispatch through all columns.
+    out.reserve(num_rows);
+    let mut row_objects: Vec<serde_json::Map<String, serde_json::Value>> =
+        (0..num_rows).map(|_| serde_json::Map::new()).collect();
+
+    for (col_idx, field) in schema.fields().iter().enumerate() {
+        let col_name = field.name().clone();
+        let column = batch.column(col_idx);
+
+        match column.data_type() {
+            DataType::Int64 => {
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .context("downcast Int64Array")?;
+                for row_idx in 0..num_rows {
+                    let v: serde_json::Value = if arr.is_null(row_idx) {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::from(arr.value(row_idx))
+                    };
+                    row_objects[row_idx].insert(col_name.clone(), v);
+                }
+            }
+            DataType::Float64 => {
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .context("downcast Float64Array")?;
+                for row_idx in 0..num_rows {
+                    let v = if arr.is_null(row_idx) {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::from(arr.value(row_idx))
+                    };
+                    row_objects[row_idx].insert(col_name.clone(), v);
+                }
+            }
+            DataType::Boolean => {
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .context("downcast BooleanArray")?;
+                for row_idx in 0..num_rows {
+                    let v = if arr.is_null(row_idx) {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::Bool(arr.value(row_idx))
+                    };
+                    row_objects[row_idx].insert(col_name.clone(), v);
+                }
+            }
+            DataType::Utf8 => {
+                let arr = column
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .context("downcast StringArray")?;
+                for row_idx in 0..num_rows {
+                    let v = if arr.is_null(row_idx) {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::String(arr.value(row_idx).to_string())
+                    };
+                    row_objects[row_idx].insert(col_name.clone(), v);
+                }
+            }
+            other => {
+                // Unsupported column type — fall back to formatted
+                // display so callers see SOMETHING rather than a
+                // crash.  Future iterations can extend the match.
+                for row_idx in 0..num_rows {
+                    row_objects[row_idx].insert(
+                        col_name.clone(),
+                        serde_json::Value::String(format!("<unsupported arrow type {other:?}>")),
+                    );
+                }
+            }
+        }
+    }
+
+    out.extend(row_objects.into_iter().map(serde_json::Value::Object));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/arrow-flight-client/src/tests.rs
+++ b/arrow-flight-client/src/tests.rs
@@ -1,0 +1,240 @@
+//! Tests use an in-process Flight server spun up on a fresh port so
+//! the client + server share an event loop without needing the live
+//! noetl-server cluster.  Mirrors the Python `test_flight_server.py`
+//! test layout from noetl/noetl#643.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
+    PollInfo, PutResult, SchemaResult, Ticket,
+};
+use futures::stream::BoxStream;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status, Streaming};
+
+use super::*;
+
+use futures::StreamExt;
+
+/// Spin up the stub Flight server on a fresh port.  Returns
+/// `(endpoint_url, shutdown_signal, last_ticket_handle)`.
+async fn start_stub_server(
+    batch: Option<RecordBatch>,
+) -> (String, oneshot::Sender<()>, Arc<tokio::sync::Mutex<Option<Vec<u8>>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local_addr");
+    let endpoint = format!("http://{addr}");
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let last_ticket = Arc::new(tokio::sync::Mutex::new(None));
+    let svc = StubFlightShared {
+        response_batch: batch,
+        last_ticket: last_ticket.clone(),
+    };
+
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming_shutdown(incoming, async {
+                rx.await.ok();
+            })
+            .await
+            .expect("serve_with_incoming_shutdown");
+    });
+    // Give the server a beat to bind.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (endpoint, tx, last_ticket)
+}
+
+/// Same shape as `StubFlight` but with `Arc<Mutex>` for the
+/// last_ticket so the test can read it across the gRPC boundary.
+struct StubFlightShared {
+    response_batch: Option<RecordBatch>,
+    last_ticket: Arc<tokio::sync::Mutex<Option<Vec<u8>>>>,
+}
+
+#[tonic::async_trait]
+impl FlightService for StubFlightShared {
+    type HandshakeStream = BoxStream<'static, Result<HandshakeResponse, Status>>;
+    type ListFlightsStream = BoxStream<'static, Result<FlightInfo, Status>>;
+    type DoGetStream = BoxStream<'static, Result<FlightData, Status>>;
+    type DoPutStream = BoxStream<'static, Result<PutResult, Status>>;
+    type DoActionStream = BoxStream<'static, Result<arrow_flight::Result, Status>>;
+    type ListActionsStream = BoxStream<'static, Result<ActionType, Status>>;
+    type DoExchangeStream = BoxStream<'static, Result<FlightData, Status>>;
+
+    async fn handshake(
+        &self,
+        _request: Request<Streaming<HandshakeRequest>>,
+    ) -> Result<Response<Self::HandshakeStream>, Status> {
+        Err(Status::unimplemented("handshake"))
+    }
+
+    async fn list_flights(&self, _request: Request<Criteria>) -> Result<Response<Self::ListFlightsStream>, Status> {
+        Ok(Response::new(Box::pin(futures::stream::empty())))
+    }
+
+    async fn get_flight_info(&self, _request: Request<FlightDescriptor>) -> Result<Response<FlightInfo>, Status> {
+        Err(Status::internal("FlightInfo lookup is not implemented in Phase A"))
+    }
+
+    async fn poll_flight_info(&self, _request: Request<FlightDescriptor>) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("poll_flight_info"))
+    }
+
+    async fn get_schema(&self, _request: Request<FlightDescriptor>) -> Result<Response<SchemaResult>, Status> {
+        Err(Status::unimplemented("get_schema"))
+    }
+
+    async fn do_get(&self, request: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
+        let ticket_bytes = request.into_inner().ticket.to_vec();
+        *self.last_ticket.lock().await = Some(ticket_bytes);
+
+        let Some(batch) = &self.response_batch else {
+            return Err(Status::unavailable(
+                "non-tabular result; fall back to HTTP /api/result/resolve",
+            ));
+        };
+
+        let schema = batch.schema();
+        let stream = futures::stream::iter(vec![Ok(batch.clone())]);
+        let encoder = arrow_flight::encode::FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .build(stream);
+        let mapped = encoder.map(|item| item.map_err(|e| Status::internal(format!("encoder error: {e}"))));
+        Ok(Response::new(Box::pin(mapped) as Self::DoGetStream))
+    }
+
+    async fn do_put(&self, _request: Request<Streaming<FlightData>>) -> Result<Response<Self::DoPutStream>, Status> {
+        Err(Status::unimplemented("do_put"))
+    }
+
+    async fn do_action(&self, _request: Request<Action>) -> Result<Response<Self::DoActionStream>, Status> {
+        Err(Status::unimplemented("do_action"))
+    }
+
+    async fn list_actions(&self, _request: Request<Empty>) -> Result<Response<Self::ListActionsStream>, Status> {
+        Ok(Response::new(Box::pin(futures::stream::empty())))
+    }
+
+    async fn do_exchange(
+        &self,
+        _request: Request<Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        Err(Status::unimplemented("do_exchange"))
+    }
+}
+
+/// Build a deterministic 3-row × 4-column sample batch.  Mirrors the
+/// `expected_rows` fixture in the Python flight_server tests.
+fn sample_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, true),
+        Field::new("username", DataType::Utf8, true),
+        Field::new("password", DataType::Utf8, true),
+        Field::new("score", DataType::Float64, true),
+    ]));
+    let id = Int64Array::from(vec![Some(1), Some(2), Some(3)]);
+    let username = StringArray::from(vec![Some("user_001"), Some("user_002"), Some("user_003")]);
+    let password = StringArray::from(vec![Some("[REDACTED]"), Some("[REDACTED]"), Some("[REDACTED]")]);
+    let score = Float64Array::from(vec![Some(0.95), Some(0.72), Some(0.88)]);
+    RecordBatch::try_new(
+        schema,
+        vec![Arc::new(id), Arc::new(username), Arc::new(password), Arc::new(score)],
+    )
+    .expect("build sample batch")
+}
+
+#[tokio::test]
+async fn resolve_returns_record_batches() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, last_ticket) = start_stub_server(Some(batch)).await;
+
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    let batches = resolver
+        .resolve("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("resolve");
+
+    // Phase A's `rows_to_arrow_ipc` produces a single batch; the
+    // stub mirrors that.
+    assert_eq!(batches.len(), 1);
+    let b = &batches[0];
+    assert_eq!(b.num_rows(), 3);
+    assert_eq!(b.num_columns(), 4);
+    assert_eq!(
+        b.schema().fields().iter().map(|f| f.name().clone()).collect::<Vec<_>>(),
+        vec!["id", "username", "password", "score"],
+    );
+
+    // Ticket bytes round-tripped end-to-end.
+    let captured = last_ticket.lock().await.clone().expect("ticket captured");
+    assert_eq!(
+        std::str::from_utf8(&captured).unwrap(),
+        "noetl://execution/12345/result/big_select/abcd1234"
+    );
+}
+
+#[tokio::test]
+async fn resolve_rows_flattens_to_json_objects() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, _last) = start_stub_server(Some(batch)).await;
+
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    let rows = resolver
+        .resolve_rows("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("resolve_rows");
+
+    assert_eq!(rows.len(), 3);
+    let first = rows[0].as_object().unwrap();
+    assert_eq!(first["id"], 1);
+    assert_eq!(first["username"], "user_001");
+    assert_eq!(first["password"], "[REDACTED]");
+    assert_eq!(first["score"].as_f64().unwrap(), 0.95);
+}
+
+#[tokio::test]
+async fn resolve_returns_non_tabular_on_unavailable() {
+    let (endpoint, _shutdown, _last) = start_stub_server(None).await;
+
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    let err = resolver
+        .resolve("noetl://execution/12345/result/shell_step/x")
+        .await
+        .expect_err("should be NonTabular");
+    match err {
+        FlightError::NonTabular { ref_uri, message } => {
+            assert_eq!(ref_uri, "noetl://execution/12345/result/shell_step/x");
+            assert!(message.contains("non-tabular") || message.contains("HTTP"));
+        }
+        other => panic!("expected NonTabular, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn connect_to_unreachable_endpoint_fails_fast() {
+    // 127.0.0.1:1 is reliably refused on every common OS (privileged
+    // port + no listener).  Connect should error within the 10s
+    // connect_timeout budget.
+    let result = FlightResolver::connect("http://127.0.0.1:1").await;
+    assert!(result.is_err(), "should error on connection refused");
+}
+
+#[tokio::test]
+async fn endpoint_accessor_returns_constructor_arg() {
+    // Build a stub so the connect call actually succeeds; we only
+    // care about the endpoint accessor here.
+    let batch = sample_batch();
+    let (endpoint, _shutdown, _last) = start_stub_server(Some(batch)).await;
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    assert_eq!(resolver.endpoint(), endpoint);
+}


### PR DESCRIPTION
## Summary

Rust consumer for the noetl-server's Arrow Flight `do_get` endpoint ([noetl/noetl#643](https://github.com/noetl/noetl/pull/643), R-2.3 Phase A).  Fetches tabular result-store payloads as Arrow IPC streams over gRPC, returning typed `RecordBatch`es with zero JSON serialisation overhead in the consumer leg.

## Why a standalone crate

Reusable across multiple Rust consumers:
- **noetl-worker** for cross-node tabular reads.
- **Rust noetl-server** once it gains a result-store backend.
- **CLI tree walker** (`noetl-executor`) for local-mode consumers.

Keeping the client in its own crate avoids coupling those consumers to each other's Cargo build graphs.  Sibling crate to `noetl-arrow-cache` (R-2.1) in the same `repos/cli` workspace.

## API

```rust
use noetl_arrow_flight_client::{FlightResolver, FlightError};

let resolver = FlightResolver::connect("grpc://noetl.noetl.svc.cluster.local:8083").await?;
match resolver.resolve("noetl://execution/12345/result/big_select/abcd1234").await {
    Ok(batches) => /* zero-copy Arrow RecordBatch ... */,
    Err(FlightError::NonTabular { ref_uri, message }) => /* fall back to HTTP /api/result/resolve */,
    Err(FlightError::Server { .. }) => /* hard error */,
    Err(FlightError::Transport { .. }) => /* network */,
}
// or the JSON-shaped convenience:
let rows = resolver.resolve_rows("noetl://...").await?; // Vec<serde_json::Value>
```

| Surface | Purpose |
|---------|---------|
| `FlightResolver::connect(endpoint)` | Long-lived gRPC channel; 10s connect timeout, 30s request timeout. |
| `FlightResolver::resolve(ref_uri)` | `Vec<RecordBatch>` — columnar. |
| `FlightResolver::resolve_rows(ref_uri)` | `Vec<serde_json::Value>` — JSON-shaped row dicts (mirrors Python `to_pylist()`). |
| `FlightResolver::endpoint()` | Accessor for logging. |

## Observability

Per `agents/rules/observability.md` Principle 1: `resolve` is wrapped in a `flight.resolve` span carrying `endpoint` + `ref_uri`; completion log carries batch count + row count.

## Test plan

- [x] 5 unit tests using an in-test Rust Flight server (mirrors the Python `test_flight_server.py` test layout from noetl/noetl#643).
- [x] `cargo test -p noetl-arrow-flight-client` — **5/5 pass**.
- [x] `cargo clippy -p noetl-arrow-flight-client --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## R-2.3 phase scope

| Phase | Status |
|-------|--------|
| A — Python server `do_get` | ✅ noetl/noetl#643, kind-validated |
| **B — this crate (Rust client + tests)** | ✅ this PR |
| Worker call-site wiring | Deferred until a concrete cross-node consumer surfaces |
| C — multi-endpoint FlightInfo, mTLS, token auth | Planned |

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)