### PR TITLE
feat(arrow-flight-client): get_flight_info discovery surface (R-2.3 Phase C1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-arrow-flight-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/arrow-flight-client/Cargo.toml
+++ b/arrow-flight-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-arrow-flight-client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"

--- a/arrow-flight-client/src/lib.rs
+++ b/arrow-flight-client/src/lib.rs
@@ -23,13 +23,19 @@
 //!
 //! ## R-2.3 phase scope
 //!
-//! Phase B (this crate) ships the standalone client.  Wiring it into
-//! a concrete consumer (the noetl-worker for cross-node tabular
-//! reads, the Rust noetl-server once it gains a result-store
-//! backend, the CLI tree walker for local-mode consumers) is
-//! deferred until a real caller surfaces.  Keeping the client in
-//! its own crate avoids coupling those consumers to each other's
-//! Cargo build graphs.
+//! Phase B (initial release) ships the standalone client + `resolve`
+//! / `resolve_rows` for materialising tabular results into typed
+//! `RecordBatch`es / JSON-shaped row dicts.  Phase C1 (this version)
+//! adds `get_flight_info` for schema + row-count discovery without
+//! materialising the payload — useful for sizing buffers or skipping
+//! the fetch entirely for non-tabular refs.
+//!
+//! Wiring the client into a concrete consumer (the noetl-worker for
+//! cross-node tabular reads, the Rust noetl-server once it gains a
+//! result-store backend, the CLI tree walker for local-mode
+//! consumers) is deferred until a real caller surfaces.  Keeping the
+//! client in its own crate avoids coupling those consumers to each
+//! other's Cargo build graphs.
 //!
 //! [wiki]: https://github.com/noetl/noetl/wiki/arrow_flight_result_fetch
 //! [execution-model]: https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md
@@ -38,9 +44,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arrow::array::RecordBatch;
+use arrow::datatypes::{Schema, SchemaRef};
 use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::flight_descriptor::DescriptorType;
 use arrow_flight::flight_service_client::FlightServiceClient;
-use arrow_flight::Ticket;
+use arrow_flight::{FlightDescriptor, FlightInfo, Ticket};
 use futures::TryStreamExt;
 use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
@@ -64,6 +72,50 @@ pub enum FlightError {
     /// Server returned some other typed Flight error.
     #[error("server error: {0}")]
     Server(String),
+}
+
+/// FlightInfo discovery summary — R-2.3 Phase C1.
+///
+/// Returned by [`FlightResolver::get_flight_info`].  Callers use
+/// it to size buffers, inspect the schema, or decide whether to
+/// follow the embedded endpoints before issuing the actual
+/// [`FlightResolver::resolve`] call.
+///
+/// Field-level mirror of `pyarrow.flight.FlightInfo` (the wire
+/// type), with the Arrow schema pre-decoded so consumers don't
+/// re-parse the IPC bytes themselves.
+#[derive(Debug, Clone)]
+pub struct FlightInfoSummary {
+    /// Arrow schema of the rowset that `do_get` would stream.
+    /// Decoded from the FlightInfo's schema IPC bytes.
+    pub schema: SchemaRef,
+    /// Total rows the server reports for this ref.  Matches what
+    /// `resolve(ref).iter().map(|b| b.num_rows()).sum()` would
+    /// produce, without paying for the materialisation.
+    pub total_records: i64,
+    /// Encoded Arrow IPC byte length.  Matches the byte count
+    /// the server would stream over `do_get`.
+    pub total_bytes: i64,
+    /// gRPC endpoint(s) that can serve the corresponding `do_get`.
+    /// Phase C1 returns exactly one; the multi-endpoint variant is
+    /// deferred until sharded result tiers land.
+    pub endpoints: Vec<FlightEndpointSummary>,
+}
+
+/// One endpoint inside a [`FlightInfoSummary`].  Same shape as
+/// `pyarrow.flight.FlightEndpoint` but bytes pre-extracted from
+/// the wire types.
+#[derive(Debug, Clone)]
+pub struct FlightEndpointSummary {
+    /// Ticket bytes — typically the same `noetl://...` URI the
+    /// caller passed to `get_flight_info`.  Consumers with a known
+    /// ref URI can skip `get_flight_info` entirely and call
+    /// `do_get` directly with the same bytes.
+    pub ticket: Vec<u8>,
+    /// gRPC URLs that can serve this ticket.  In a single-server
+    /// deployment this is `[self.endpoint]`; future multi-endpoint
+    /// sharding adds entries here.
+    pub locations: Vec<String>,
 }
 
 /// Thin wrapper around `arrow_flight::FlightServiceClient` that
@@ -106,6 +158,79 @@ impl FlightResolver {
     /// Endpoint this resolver is connected to.  Useful for logging.
     pub fn endpoint(&self) -> &str {
         &self.endpoint
+    }
+
+    /// R-2.3 Phase C1: fetch the [`FlightInfoSummary`] (schema + row
+    /// count + endpoints) for a ref URI without materialising the
+    /// underlying rowset.  Useful for clients that want to:
+    ///
+    /// - Inspect the schema before sizing buffers.
+    /// - Decide between Flight + the HTTP fallback based on row
+    ///   count / byte total.
+    /// - Discover which endpoint to call `do_get` against in a
+    ///   future multi-endpoint deployment (Phase C1 always returns
+    ///   one endpoint, but the API shape is stable for sharding).
+    ///
+    /// Wire convention: the descriptor's `cmd` field carries the
+    /// noetl:// URI bytes — same convention as the Ticket the
+    /// server returns inside the FlightEndpoint, so a consumer
+    /// with a known ref URI can skip `get_flight_info` entirely
+    /// and call [`resolve`] directly.
+    ///
+    /// Per `observability.md` Principle 1, the call is wrapped in
+    /// a `flight.get_flight_info` span carrying `endpoint` +
+    /// `ref_uri`.
+    pub async fn get_flight_info(&self, ref_uri: &str) -> Result<FlightInfoSummary, FlightError> {
+        let span = tracing::info_span!(
+            "flight.get_flight_info",
+            endpoint = %self.endpoint,
+            ref_uri = %ref_uri,
+        );
+        let _enter = span.enter();
+
+        let descriptor = FlightDescriptor {
+            r#type: DescriptorType::Cmd as i32,
+            cmd: ref_uri.as_bytes().to_vec().into(),
+            path: Vec::new(),
+        };
+        let mut client = self.client.clone();
+        let info: FlightInfo = match client.get_flight_info(descriptor).await {
+            Ok(response) => response.into_inner(),
+            Err(status) => return Err(classify_status(ref_uri, &status)),
+        };
+
+        // Decode the IPC-encoded schema bytes via arrow-flight's
+        // `Schema::try_from(FlightInfo)` impl — clone the info
+        // because the impl consumes it, but we still need
+        // `info.endpoint` + the totals below.
+        let schema: Schema = Schema::try_from(info.clone())
+            .map_err(|e| FlightError::Server(format!("decode schema for ref {ref_uri}: {e}")))?;
+        let schema_ref: SchemaRef = std::sync::Arc::new(schema);
+
+        let endpoints = info
+            .endpoint
+            .iter()
+            .map(|ep| FlightEndpointSummary {
+                ticket: ep.ticket.as_ref().map(|t| t.ticket.to_vec()).unwrap_or_default(),
+                locations: ep.location.iter().map(|loc| loc.uri.clone()).collect(),
+            })
+            .collect();
+
+        tracing::info!(
+            endpoint = %self.endpoint,
+            ref_uri = %ref_uri,
+            total_records = info.total_records,
+            total_bytes = info.total_bytes,
+            n_endpoints = info.endpoint.len(),
+            "flight.get_flight_info completed",
+        );
+
+        Ok(FlightInfoSummary {
+            schema: schema_ref,
+            total_records: info.total_records,
+            total_bytes: info.total_bytes,
+            endpoints,
+        })
     }
 
     /// Submit `ref_uri` as a Flight Ticket and collect the streamed

--- a/arrow-flight-client/src/tests.rs
+++ b/arrow-flight-client/src/tests.rs
@@ -82,8 +82,47 @@ impl FlightService for StubFlightShared {
         Ok(Response::new(Box::pin(futures::stream::empty())))
     }
 
-    async fn get_flight_info(&self, _request: Request<FlightDescriptor>) -> Result<Response<FlightInfo>, Status> {
-        Err(Status::internal("FlightInfo lookup is not implemented in Phase A"))
+    async fn get_flight_info(&self, request: Request<FlightDescriptor>) -> Result<Response<FlightInfo>, Status> {
+        let descriptor = request.into_inner();
+        if descriptor.r#type != arrow_flight::flight_descriptor::DescriptorType::Cmd as i32 {
+            return Err(Status::internal("Cmd-shaped descriptor required"));
+        }
+        let Some(batch) = &self.response_batch else {
+            return Err(Status::unavailable(
+                "non-tabular result; fall back to HTTP /api/result/resolve",
+            ));
+        };
+
+        // Serialise the schema as Arrow IPC bytes (same wire shape
+        // the Python server returns).
+        let schema = batch.schema();
+        let options = arrow::ipc::writer::IpcWriteOptions::default();
+        let schema_data = arrow_flight::SchemaAsIpc::new(&schema, &options);
+        let schema_bytes: arrow_flight::IpcMessage = schema_data
+            .try_into()
+            .map_err(|e| Status::internal(format!("schema encode: {e}")))?;
+
+        let ticket_bytes = descriptor.cmd.clone();
+        let endpoint = arrow_flight::FlightEndpoint {
+            ticket: Some(arrow_flight::Ticket {
+                ticket: ticket_bytes.clone(),
+            }),
+            location: vec![arrow_flight::Location {
+                uri: "grpc://test-server".to_string(),
+            }],
+            expiration_time: None,
+            app_metadata: Default::default(),
+        };
+        let info = FlightInfo {
+            schema: schema_bytes.0,
+            flight_descriptor: Some(descriptor),
+            endpoint: vec![endpoint],
+            total_records: batch.num_rows() as i64,
+            total_bytes: 0,
+            ordered: false,
+            app_metadata: Default::default(),
+        };
+        Ok(Response::new(info))
     }
 
     async fn poll_flight_info(&self, _request: Request<FlightDescriptor>) -> Result<Response<PollInfo>, Status> {
@@ -227,6 +266,54 @@ async fn connect_to_unreachable_endpoint_fails_fast() {
     // connect_timeout budget.
     let result = FlightResolver::connect("http://127.0.0.1:1").await;
     assert!(result.is_err(), "should error on connection refused");
+}
+
+#[tokio::test]
+async fn get_flight_info_returns_schema_and_endpoint() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, _last_ticket) = start_stub_server(Some(batch)).await;
+
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    let info = resolver
+        .get_flight_info("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("get_flight_info");
+
+    assert_eq!(info.total_records, 3);
+    assert_eq!(info.endpoints.len(), 1);
+    let ep = &info.endpoints[0];
+    // The ticket the stub server hands back is the same bytes
+    // we sent in as the descriptor command — round-trip parity.
+    assert_eq!(
+        std::str::from_utf8(&ep.ticket).unwrap(),
+        "noetl://execution/12345/result/big_select/abcd1234"
+    );
+    assert!(!ep.locations.is_empty());
+    // Schema names match the sample batch.
+    assert_eq!(
+        info.schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>(),
+        vec!["id", "username", "password", "score"],
+    );
+}
+
+#[tokio::test]
+async fn get_flight_info_returns_non_tabular_on_unavailable() {
+    let (endpoint, _shutdown, _last_ticket) = start_stub_server(None).await;
+    let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
+    let err = resolver
+        .get_flight_info("noetl://execution/12345/result/shell_step/x")
+        .await
+        .expect_err("should be NonTabular");
+    match err {
+        FlightError::NonTabular { ref_uri, .. } => {
+            assert_eq!(ref_uri, "noetl://execution/12345/result/shell_step/x");
+        }
+        other => panic!("expected NonTabular, got {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds `FlightResolver::get_flight_info(ref_uri) -> FlightInfoSummary` mirroring the Python server's matching surface from [noetl/noetl#644](https://github.com/noetl/noetl/pull/644).  Consumers can read the Arrow schema + row count + endpoint(s) for a ref URI without materialising the full payload via `resolve`.

## Why

Useful for clients that want to:

- Inspect the schema before sizing buffers (`SchemaRef` pre-decoded from the IPC bytes, no manual parsing).
- Decide between Flight + the HTTP fallback based on row count or byte total without paying for the materialisation.
- Discover which endpoint to call `resolve` against in a future multi-endpoint deployment (Phase C1 always returns one, but the API shape is stable for sharding).

## API additions

```rust
pub struct FlightInfoSummary {
    pub schema: SchemaRef,
    pub total_records: i64,
    pub total_bytes: i64,
    pub endpoints: Vec<FlightEndpointSummary>,
}
pub struct FlightEndpointSummary {
    pub ticket: Vec<u8>,
    pub locations: Vec<String>,
}
impl FlightResolver {
    pub async fn get_flight_info(&self, ref_uri: &str) -> Result<FlightInfoSummary, FlightError>;
}
```

The ticket bytes inside `FlightEndpointSummary` are typically the same `noetl://...` URI the caller passed to `get_flight_info` — consumers with a known ref URI can skip the round-trip and call `resolve` directly with the same bytes.

## Wire convention

The descriptor's `cmd` field carries the noetl:// URI bytes, matching the Ticket convention from Phase A.  The schema bytes ride through arrow-rs's `Schema::try_from(FlightInfo)` impl so callers don't have to round-trip through arrow-flight's IPC decoder themselves.

## Test plan

- [x] **7/7 tests pass** (5 from Phase B + 2 new):
  - `get_flight_info_returns_schema_and_endpoint`: round-trip via the in-test Rust Flight stub.  Asserts `total_records=3`, ticket round-trips, schema field names match.
  - `get_flight_info_returns_non_tabular_on_unavailable`: server returns Status::unavailable → client surfaces `FlightError::NonTabular`.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Version bump

0.1.0 → 0.2.0 (minor: additive public API).  Same release-pipeline shape as Phase B ([#41](https://github.com/noetl/cli/pull/41)); auto-publishes after merge via the explicit publish block from [#42](https://github.com/noetl/cli/pull/42).

## Phase scope

| Phase | Status |
|-------|--------|
| A — Python server `do_get` | ✅ |
| B — Rust client `resolve` / `resolve_rows` | ✅ on crates.io 0.1.0 |
| C1 — Python server `get_flight_info` | [noetl/noetl#644](https://github.com/noetl/noetl/pull/644) |
| **C1 — Rust client `get_flight_info` (this PR)** | open |
| C2 — mTLS + token auth | Deferred |
| Multi-endpoint sharding | Deferred |

Refs noetl/ai-meta#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)