### PR TITLE
docs(arrow-flight-client): clarify FlightResolver::connect scheme requirement

### DIFF
--- a/arrow-flight-client/src/lib.rs
+++ b/arrow-flight-client/src/lib.rs
@@ -132,8 +132,16 @@ pub struct FlightResolver {
 
 impl FlightResolver {
     /// Connect to the noetl-server's Flight endpoint.  `endpoint`
-    /// must be a gRPC URL such as `grpc://localhost:8083` or
-    /// `grpc://noetl.noetl.svc.cluster.local:8083`.
+    /// must be a tonic-compatible URL — `http://...` for plaintext
+    /// h2c (default in kind + GKE without TLS) or `https://...` for
+    /// TLS-fronted deployments.  Examples:
+    /// `http://localhost:8083`, `http://noetl.noetl.svc.cluster.local:8083`,
+    /// `https://noetl.example.com:8083`.
+    ///
+    /// The `grpc://` scheme some Flight clients (Java, Python pyarrow)
+    /// accept is NOT valid for tonic — HTTP/2's `:scheme`
+    /// pseudo-header must be `http` or `https`, so `grpc://` surfaces
+    /// as `Bad :scheme header` at first request time.
     ///
     /// Honors a 10s connect timeout — Flight is on the cluster
     /// network and a slow connect almost always means the server


### PR DESCRIPTION
## Summary

The previous doc comment on `FlightResolver::connect` told callers to pass `grpc://...` URLs.  That works with the Java + Python pyarrow Flight clients but NOT with tonic — HTTP/2's `:scheme` pseudo-header must be `http` or `https`, so `grpc://` surfaces as `Bad :scheme header` at first request time.

Caught by the `noetl/ops` kind-validation rig for the `result_fetch` tool kind, where `derive_flight_endpoint` in `noetl/tools` was following this doc and producing `grpc://...:8083` URLs that broke at request time.

## Test plan

- [x] Doc-only change; existing tests still pass (`cargo test` — 0 client tests, the crate is integration-tested via `noetl/tools`).

## Followup

- Matching code fix in noetl/tools#9 (`derive_flight_endpoint` now emits `http://` / `https://`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)