### PR TITLE
feat(arrow-flight-client): TLS client config (R-2.3 Phase C2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +693,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1136,6 +1184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1222,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -2522,6 +2599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,12 +2722,13 @@ dependencies = [
 
 [[package]]
 name = "noetl-arrow-flight-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",
  "arrow-flight",
  "futures",
+ "rcgen",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -2704,6 +2788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2847,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2821,6 +2921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3056,6 +3165,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3345,6 +3460,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,6 +3693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -4245,6 +4383,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,8 +4587,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -5437,6 +5608,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5444,6 +5633,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/arrow-flight-client/Cargo.toml
+++ b/arrow-flight-client/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "noetl-arrow-flight-client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"
 homepage = "https://noetl.io"
-description = "NoETL Arrow Flight client — Rust consumer for the noetl-server's /api/result Flight gRPC endpoint (R-2.3 Phase B)"
+description = "NoETL Arrow Flight client — Rust consumer for the noetl-server's /api/result Flight gRPC endpoint (R-2.3 Phase B + C1 + C2.2)"
 keywords = ["arrow", "flight", "grpc", "noetl"]
 categories = ["api-bindings", "data-structures"]
 readme = "README.md"
@@ -20,8 +20,14 @@ arrow = "53"
 # Async runtime + tonic transport.  arrow-flight 53 builds on
 # tonic 0.12 + tokio; pin them explicitly so the compile graph
 # is stable.
+#
+# `tls` feature (R-2.3 Phase C2.2) enables `ClientTlsConfig` +
+# `Certificate` + `Identity` for talking to a TLS-fronted Flight
+# server.  The transport uses rustls (the default for tonic's tls
+# feature) which honors the URL scheme — `http://` for plaintext
+# h2c, `https://` triggers the TLS handshake.
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
-tonic = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
 futures = "0.3"
 
 # Error handling — Anyhow for the public API + thiserror for typed
@@ -44,3 +50,10 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 tokio-stream = { version = "0.1", features = ["net"] }
 arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
 futures = "0.3"
+
+# R-2.3 Phase C2.2 — `rcgen` generates a self-signed cert + key pair
+# in-process so the TLS integration test can spin up a TLS-enabled
+# Flight server without checking certs into the repo (per
+# `agents/rules/safety.md`).  Test-only dep; never on the runtime
+# build graph.
+rcgen = "0.14"

--- a/arrow-flight-client/src/lib.rs
+++ b/arrow-flight-client/src/lib.rs
@@ -23,12 +23,20 @@
 //!
 //! ## R-2.3 phase scope
 //!
-//! Phase B (initial release) ships the standalone client + `resolve`
-//! / `resolve_rows` for materialising tabular results into typed
-//! `RecordBatch`es / JSON-shaped row dicts.  Phase C1 (this version)
-//! adds `get_flight_info` for schema + row-count discovery without
-//! materialising the payload — useful for sizing buffers or skipping
-//! the fetch entirely for non-tabular refs.
+//! Phase B (0.1.0) ships the standalone client + `resolve` /
+//! `resolve_rows` for materialising tabular results into typed
+//! `RecordBatch`es / JSON-shaped row dicts.  Phase C1 (0.2.0) adds
+//! `get_flight_info` for schema + row-count discovery without
+//! materialising the payload — useful for sizing buffers or
+//! skipping the fetch entirely for non-tabular refs.  Phase C2.2
+//! (0.3.0, this version) adds [`FlightTlsConfig`] +
+//! [`FlightResolver::connect_with_tls`] so the client can talk to a
+//! TLS-fronted Flight endpoint (the server side opted into via
+//! `NOETL_FLIGHT_TLS_CERT` + `NOETL_FLIGHT_TLS_KEY` in Phase C2.1).
+//!
+//! Bearer-token middleware (C2.3) + mTLS client identity (C2.4) ride
+//! on top of this configuration surface — see the Phase C2 umbrella
+//! at noetl/ai-meta#33.
 //!
 //! Wiring the client into a concrete consumer (the noetl-worker for
 //! cross-node tabular reads, the Rust noetl-server once it gains a
@@ -51,7 +59,7 @@ use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::{FlightDescriptor, FlightInfo, Ticket};
 use futures::TryStreamExt;
 use thiserror::Error;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 
 /// Typed error variants for `resolve()` failures.  Callers usually
 /// match on the variant to decide between fall-back paths (HTTP
@@ -118,6 +126,86 @@ pub struct FlightEndpointSummary {
     pub locations: Vec<String>,
 }
 
+/// TLS configuration for the gRPC channel — R-2.3 Phase C2.2.
+///
+/// Pass to [`FlightResolver::connect_with_tls`] to talk to a
+/// TLS-fronted noetl-server Flight endpoint (the `NOETL_FLIGHT_TLS_*`
+/// envs the server side opted into in Phase C2.1).  The
+/// `ca_certificate` field carries the PEM-encoded server CA bundle —
+/// required when the server presents a non-public cert (the typical
+/// in-cluster case where a private CA signs the Flight cert).
+///
+/// `domain_name` overrides the SNI / cert verification hostname.
+/// When unset the host portion of the connection URL is used.
+/// Useful when the endpoint URL is an IP (or a service-internal DNS
+/// name) but the cert was issued for a different SAN.
+///
+/// Client-side identity (mTLS) is reserved for Phase C2.4 — when
+/// that lands this struct gains an `identity` field carrying the
+/// `(client_cert_pem, client_key_pem)` pair.
+///
+/// ## Example — explicit CA + SNI override
+///
+/// ```no_run
+/// # use noetl_arrow_flight_client::{FlightResolver, FlightTlsConfig};
+/// # async fn run() -> anyhow::Result<()> {
+/// let ca_pem = std::fs::read("/etc/noetl/flight-ca.pem")?;
+/// let tls = FlightTlsConfig::new()
+///     .ca_certificate(ca_pem)
+///     .domain_name("noetl-flight.svc.cluster.local");
+///
+/// let resolver = FlightResolver::connect_with_tls(
+///     "https://noetl.example.com:8083",
+///     tls,
+/// ).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct FlightTlsConfig {
+    ca_pem: Option<Vec<u8>>,
+    domain_name: Option<String>,
+}
+
+impl FlightTlsConfig {
+    /// New empty TLS config — relies on the URL scheme + tonic's
+    /// built-in defaults (system roots when available).  Equivalent
+    /// to passing the URL directly to [`FlightResolver::connect`]
+    /// with an `https://` scheme.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the PEM-encoded CA certificate the server's cert must
+    /// chain to.  When unset the channel falls back to tonic's
+    /// default trust roots (system roots when the `tls-roots`
+    /// feature is on; the empty trust store otherwise).
+    pub fn ca_certificate(mut self, ca_pem: impl Into<Vec<u8>>) -> Self {
+        self.ca_pem = Some(ca_pem.into());
+        self
+    }
+
+    /// Override the SNI / cert verification hostname.  Useful when
+    /// the endpoint URL is an IP or service-internal DNS but the
+    /// cert was issued for a different SAN.
+    pub fn domain_name(mut self, name: impl Into<String>) -> Self {
+        self.domain_name = Some(name.into());
+        self
+    }
+
+    /// Compose the underlying `tonic::transport::ClientTlsConfig`.
+    fn to_tonic(&self) -> ClientTlsConfig {
+        let mut tls = ClientTlsConfig::new();
+        if let Some(ca) = &self.ca_pem {
+            tls = tls.ca_certificate(Certificate::from_pem(ca));
+        }
+        if let Some(domain) = &self.domain_name {
+            tls = tls.domain_name(domain.clone());
+        }
+        tls
+    }
+}
+
 /// Thin wrapper around `arrow_flight::FlightServiceClient` that
 /// turns ref URIs into `RecordBatch` streams.
 ///
@@ -147,12 +235,51 @@ impl FlightResolver {
     /// network and a slow connect almost always means the server
     /// pod is unhealthy; failing fast lets the caller switch to the
     /// HTTP fallback or surface a clearer error.
+    ///
+    /// For TLS connections that need an explicit CA bundle (the
+    /// typical in-cluster case where a private CA signs the Flight
+    /// cert), use [`Self::connect_with_tls`] instead.  Bare
+    /// `https://` URLs through this method rely on tonic's default
+    /// trust roots, which may not include the cluster CA.
     pub async fn connect(endpoint: impl Into<String>) -> Result<Self> {
-        let endpoint_str = endpoint.into();
-        let channel = Endpoint::from_shared(endpoint_str.clone())
+        Self::connect_inner(endpoint.into(), None).await
+    }
+
+    /// R-2.3 Phase C2.2: connect with explicit TLS configuration.
+    ///
+    /// Use this when the noetl-server Flight endpoint is TLS-fronted
+    /// (Phase C2.1) and the server cert chains to a CA that isn't in
+    /// tonic's default trust roots — almost always the case in
+    /// cluster-internal deployments where a private CA signs the
+    /// Flight cert.
+    ///
+    /// The endpoint URL must use the `https://` scheme; an `http://`
+    /// URL with TLS config attached will fail at the tonic layer.
+    /// Bare `https://` without a TLS config relies on the default
+    /// trust roots — fine for public TLS, not for private CAs.
+    ///
+    /// See [`FlightTlsConfig`] for the builder; [Phase C2 umbrella][issue]
+    /// for the wider trust-boundary plan (bearer-token middleware is
+    /// C2.3, mTLS client identity is C2.4).
+    ///
+    /// [issue]: https://github.com/noetl/ai-meta/issues/33
+    pub async fn connect_with_tls(endpoint: impl Into<String>, tls: FlightTlsConfig) -> Result<Self> {
+        Self::connect_inner(endpoint.into(), Some(tls)).await
+    }
+
+    async fn connect_inner(endpoint_str: String, tls: Option<FlightTlsConfig>) -> Result<Self> {
+        let mut endpoint = Endpoint::from_shared(endpoint_str.clone())
             .with_context(|| format!("parse Flight endpoint {endpoint_str}"))?
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(30));
+
+        if let Some(tls) = tls {
+            endpoint = endpoint
+                .tls_config(tls.to_tonic())
+                .with_context(|| format!("configure TLS for Flight endpoint {endpoint_str}"))?;
+        }
+
+        let channel = endpoint
             .connect()
             .await
             .with_context(|| format!("connect to Flight endpoint {endpoint_str}"))?;

--- a/arrow-flight-client/src/tests.rs
+++ b/arrow-flight-client/src/tests.rs
@@ -325,3 +325,142 @@ async fn endpoint_accessor_returns_constructor_arg() {
     let resolver = FlightResolver::connect(&endpoint).await.expect("connect");
     assert_eq!(resolver.endpoint(), endpoint);
 }
+
+// ---------------------------------------------------------------------------
+// R-2.3 Phase C2.2 — Client-side TLS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tls_config_default_is_empty() {
+    let cfg = FlightTlsConfig::new();
+    // The struct has no `pub` fields so we can't introspect directly,
+    // but we can confirm to_tonic() doesn't panic for the empty case —
+    // i.e. a TLS handshake without CA override uses tonic's default
+    // trust roots.
+    let _tonic = cfg.to_tonic();
+}
+
+#[test]
+fn tls_config_builder_chains() {
+    let cfg = FlightTlsConfig::new()
+        .ca_certificate(b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----".to_vec())
+        .domain_name("flight.example.com");
+    // to_tonic() must consume both knobs without erroring.  We can't
+    // peek inside `ClientTlsConfig` from outside tonic, but the
+    // integration test below proves the wire path works end-to-end.
+    let _tonic = cfg.to_tonic();
+}
+
+#[test]
+fn tls_config_default_trait() {
+    // Default::default() is equivalent to FlightTlsConfig::new() —
+    // useful when callers pass the config via `..Default::default()`.
+    let cfg1 = FlightTlsConfig::default();
+    let cfg2 = FlightTlsConfig::new();
+    let _ = (cfg1.to_tonic(), cfg2.to_tonic());
+}
+
+/// Spin up a TLS-enabled in-process Flight server using a self-signed
+/// cert from rcgen.  Returns `(https://endpoint, shutdown_tx, ca_pem_bytes)`.
+async fn start_tls_stub_server(
+    batch: Option<RecordBatch>,
+) -> (
+    String,
+    oneshot::Sender<()>,
+    Vec<u8>,
+    Arc<tokio::sync::Mutex<Option<Vec<u8>>>>,
+) {
+    // Self-signed cert + key for SAN `localhost` — matches the
+    // SNI the client uses when connecting to `https://localhost:<port>`.
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("generate self-signed cert");
+    let cert_pem = cert.cert.pem();
+    let key_pem = cert.signing_key.serialize_pem();
+
+    let identity = tonic::transport::Identity::from_pem(cert_pem.as_bytes(), key_pem.as_bytes());
+    let tls = tonic::transport::ServerTlsConfig::new().identity(identity);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local_addr");
+    // The SNI hostname has to match the cert SAN (`localhost`), but
+    // we also need a working port — use `localhost` for the URL host
+    // + the bound port from the listener.
+    let endpoint = format!("https://localhost:{}", addr.port());
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let last_ticket = Arc::new(tokio::sync::Mutex::new(None));
+    let svc = StubFlightShared {
+        response_batch: batch,
+        last_ticket: last_ticket.clone(),
+    };
+
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        Server::builder()
+            .tls_config(tls)
+            .expect("server tls_config")
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming_shutdown(incoming, async {
+                rx.await.ok();
+            })
+            .await
+            .expect("serve_with_incoming_shutdown");
+    });
+    // Give the server a beat to bind.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let ca_pem = cert_pem.into_bytes();
+    (endpoint, tx, ca_pem, last_ticket)
+}
+
+#[tokio::test]
+async fn connect_with_tls_round_trips_against_self_signed_server() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, ca_pem, _last_ticket) = start_tls_stub_server(Some(batch.clone())).await;
+
+    // With the matching CA the client must succeed.  Note the
+    // `domain_name("localhost")` override isn't strictly required
+    // here (the URL already says localhost) but it pins the test
+    // against the cert SAN explicitly so a future endpoint change
+    // doesn't silently break SNI.
+    let tls = FlightTlsConfig::new().ca_certificate(ca_pem).domain_name("localhost");
+    let resolver = FlightResolver::connect_with_tls(&endpoint, tls)
+        .await
+        .expect("connect_with_tls");
+
+    let batches = resolver
+        .resolve("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("resolve over TLS");
+
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].num_rows(), batch.num_rows());
+}
+
+#[tokio::test]
+async fn connect_with_tls_rejects_when_ca_missing() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, _ca_pem, _last_ticket) = start_tls_stub_server(Some(batch)).await;
+
+    // Empty TLS config — tonic falls back to the default trust
+    // store, which does NOT contain our self-signed CA.  Connect
+    // must fail at the TLS handshake.
+    let tls = FlightTlsConfig::new().domain_name("localhost");
+    let result = FlightResolver::connect_with_tls(&endpoint, tls).await;
+    assert!(result.is_err(), "expected TLS handshake to fail without CA, got Ok",);
+}
+
+#[tokio::test]
+async fn connect_plain_https_without_tls_config_fails() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, _ca_pem, _last_ticket) = start_tls_stub_server(Some(batch)).await;
+
+    // `connect()` (no tls_config) against an `https://` server
+    // without a matching CA in the default trust store should fail
+    // too — locks in that the API doesn't silently accept untrusted
+    // server certs.
+    let result = FlightResolver::connect(&endpoint).await;
+    assert!(
+        result.is_err(),
+        "expected plaintext-API + https endpoint to fail without trust roots",
+    );
+}


### PR DESCRIPTION
## Summary

Second slice of R-2.3 Phase C2 — the Rust Flight client gains a configurable TLS surface so it can talk to the TLS-fronted server the Phase C2.1 opt-in introduced (noetl/noetl#646).

- Bumps `noetl-arrow-flight-client` to 0.3.0.
- Enables tonic's `tls` feature (pulls in rustls + tokio-rustls; `FlightServiceClient` channels negotiate TLS on `https://` URLs).
- New `FlightTlsConfig` builder — `ca_certificate(pem)` + `domain_name(host)`.
- New `FlightResolver::connect_with_tls(endpoint, tls)` — same shape as `connect()` but threads `ClientTlsConfig` into the tonic Endpoint.
- `connect()` stays plaintext h2c by default; bare `https://` URLs through `connect()` rely on tonic's default trust roots which usually don't include the cluster CA.
- mTLS client identity is reserved for Phase C2.4 — adds an `identity(cert_pem, key_pem)` builder on the same struct.

## Test plan

- [x] 3 unit tests pin the builder semantics: `tls_config_default_is_empty`, `tls_config_builder_chains`, `tls_config_default_trait`.
- [x] 3 integration tests using rcgen-generated self-signed certs + a `Server::builder().tls_config(...)` stub:
    - `connect_with_tls_round_trips_against_self_signed_server` — full TLS handshake + Flight do_get round-trip.
    - `connect_with_tls_rejects_when_ca_missing` — empty TLS config → handshake fails (no trust root for our self-signed CA).
    - `connect_plain_https_without_tls_config_fails` — `connect()` against `https://` without matching CA also fails, locking in that the API doesn't silently accept untrusted server certs.
- [x] All 13 tests pass; `cargo fmt` clean; `cargo clippy --tests` clean.
- [x] Per `agents/rules/safety.md` no certs checked in; rcgen generates them per test run.

## Followup

Tracked under noetl/ai-meta#33:
- C2.3 — Bearer-token middleware (server validator + client interceptor).
- C2.4 — mTLS client identity (`FlightTlsConfig::identity(...)`).
- C2.5 — K8s manifests + cert provisioning.
- C2.6 — Kind validation rig for the TLS+auth combo.

Refs noetl/ai-meta#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)