### PR TITLE
feat(arrow-flight-client): mTLS client identity (R-2.3 Phase C2.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-arrow-flight-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/arrow-flight-client/Cargo.toml
+++ b/arrow-flight-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-arrow-flight-client"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"

--- a/arrow-flight-client/src/lib.rs
+++ b/arrow-flight-client/src/lib.rs
@@ -31,14 +31,17 @@
 //! [`FlightTlsConfig`] + [`FlightResolver::connect_with_tls`] so the
 //! client can talk to a TLS-fronted Flight endpoint (the server side
 //! opted into via `NOETL_FLIGHT_TLS_CERT` + `NOETL_FLIGHT_TLS_KEY` in
-//! Phase C2.1).  Phase C2.3 (0.4.0, this version) adds
-//! [`FlightAuth`] + [`FlightConfig`] + [`FlightResolver::connect_with`]
-//! so the client can send `Authorization: Bearer <token>` on every
-//! gRPC call, validated by the server's bearer-token middleware
-//! (`NOETL_FLIGHT_BEARER_TOKENS`).
+//! Phase C2.1).  Phase C2.3 (0.4.0) adds [`FlightAuth`] +
+//! [`FlightConfig`] + [`FlightResolver::connect_with`] so the
+//! client can send `Authorization: Bearer <token>` on every gRPC
+//! call, validated by the server's bearer-token middleware
+//! (`NOETL_FLIGHT_BEARER_TOKENS`).  Phase C2.4 (0.5.0, this
+//! version) adds [`FlightTlsConfig::identity`] so the client can
+//! present a client certificate during the TLS handshake when the
+//! server requires mutual TLS (`NOETL_FLIGHT_CLIENT_CA`,
+//! noetl/noetl#648).
 //!
-//! mTLS client identity (C2.4) rides on the same `FlightTlsConfig`
-//! builder — see the Phase C2 umbrella at noetl/ai-meta#33.
+//! See the Phase C2 umbrella at noetl/ai-meta#33 for the wider plan.
 //!
 //! Wiring the client into a concrete consumer (the noetl-worker for
 //! cross-node tabular reads, the Rust noetl-server once it gains a
@@ -61,7 +64,7 @@ use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::{FlightDescriptor, FlightInfo, Ticket};
 use futures::TryStreamExt;
 use thiserror::Error;
-use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 
 /// Typed error variants for `resolve()` failures.  Callers usually
 /// match on the variant to decide between fall-back paths (HTTP
@@ -142,9 +145,10 @@ pub struct FlightEndpointSummary {
 /// Useful when the endpoint URL is an IP (or a service-internal DNS
 /// name) but the cert was issued for a different SAN.
 ///
-/// Client-side identity (mTLS) is reserved for Phase C2.4 — when
-/// that lands this struct gains an `identity` field carrying the
-/// `(client_cert_pem, client_key_pem)` pair.
+/// Client-side identity (mTLS, Phase C2.4) is configured via
+/// `identity(cert_pem, key_pem)`.  When the server is started with
+/// `NOETL_FLIGHT_CLIENT_CA` set (noetl/noetl#648) it requires every
+/// client to present a cert chaining to that CA on the TLS handshake.
 ///
 /// ## Example — explicit CA + SNI override
 ///
@@ -163,10 +167,35 @@ pub struct FlightEndpointSummary {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// ## Example — mTLS (Phase C2.4)
+///
+/// ```no_run
+/// # use noetl_arrow_flight_client::{FlightResolver, FlightConfig, FlightTlsConfig};
+/// # async fn run() -> anyhow::Result<()> {
+/// let ca_pem = std::fs::read("/etc/noetl/flight-ca.pem")?;
+/// let client_cert = std::fs::read("/etc/noetl/worker-client.crt")?;
+/// let client_key = std::fs::read("/etc/noetl/worker-client.key")?;
+/// let tls = FlightTlsConfig::new()
+///     .ca_certificate(ca_pem)
+///     .identity(client_cert, client_key);
+/// let cfg = FlightConfig::new().tls(tls);
+///
+/// let resolver = FlightResolver::connect_with(
+///     "https://noetl.example.com:8083",
+///     cfg,
+/// ).await?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Default, Clone)]
 pub struct FlightTlsConfig {
     ca_pem: Option<Vec<u8>>,
     domain_name: Option<String>,
+    /// R-2.3 Phase C2.4 — `(cert_pem, key_pem)` pair the client
+    /// presents on the TLS handshake when the server demands a
+    /// client cert.  Both must be set together or both None.
+    identity_pem: Option<(Vec<u8>, Vec<u8>)>,
 }
 
 impl FlightTlsConfig {
@@ -195,6 +224,29 @@ impl FlightTlsConfig {
         self
     }
 
+    /// R-2.3 Phase C2.4: set the client-side identity (cert + key)
+    /// the resolver presents on the TLS handshake.  Required when
+    /// the noetl-server is started with `NOETL_FLIGHT_CLIENT_CA`
+    /// set (mutual TLS).
+    ///
+    /// Both PEM blobs must be valid — `Identity::from_pem` accepts
+    /// them in their on-disk form (the same format the k8s Secret
+    /// would mount on the worker pod).  The pair is stored as
+    /// `(cert_pem, key_pem)` and converted to a `tonic::transport::Identity`
+    /// lazily inside `to_tonic`.
+    ///
+    /// Per [`agents/rules/execution-model.md`][exec], the client
+    /// cert + key are business-logic credentials and should be
+    /// resolved from a NoETL-managed secret (k8s Secret mounted on
+    /// the worker pod, in the usual case) rather than embedded in
+    /// playbook config.
+    ///
+    /// [exec]: https://github.com/noetl/ai-meta/blob/main/agents/rules/execution-model.md
+    pub fn identity(mut self, cert_pem: impl Into<Vec<u8>>, key_pem: impl Into<Vec<u8>>) -> Self {
+        self.identity_pem = Some((cert_pem.into(), key_pem.into()));
+        self
+    }
+
     /// Compose the underlying `tonic::transport::ClientTlsConfig`.
     fn to_tonic(&self) -> ClientTlsConfig {
         let mut tls = ClientTlsConfig::new();
@@ -203,6 +255,9 @@ impl FlightTlsConfig {
         }
         if let Some(domain) = &self.domain_name {
             tls = tls.domain_name(domain.clone());
+        }
+        if let Some((cert_pem, key_pem)) = &self.identity_pem {
+            tls = tls.identity(Identity::from_pem(cert_pem, key_pem));
         }
         tls
     }

--- a/arrow-flight-client/src/tests.rs
+++ b/arrow-flight-client/src/tests.rs
@@ -661,3 +661,179 @@ async fn connect_with_combined_tls_and_bearer() {
         .expect("resolve over combined config");
     assert_eq!(batches.len(), 1);
 }
+
+// ---------------------------------------------------------------------------
+// R-2.3 Phase C2.4 — Client-side mTLS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tls_config_identity_chains_with_other_knobs() {
+    // Builder is order-independent + can stack with ca_certificate +
+    // domain_name.  `to_tonic()` shouldn't panic when all three are
+    // set.
+    let _cfg = FlightTlsConfig::new()
+        .ca_certificate(b"fake-ca".to_vec())
+        .identity(b"fake-cert".to_vec(), b"fake-key".to_vec())
+        .domain_name("flight.example.com");
+    // We can't introspect ClientTlsConfig from outside tonic, but
+    // the integration test below proves the wire path works.
+}
+
+#[test]
+fn tls_config_identity_only_no_ca() {
+    // Identity without an explicit CA is still a valid construct —
+    // the client trusts the default roots, the server still gets the
+    // client identity.
+    let _cfg = FlightTlsConfig::new().identity(b"fake-cert".to_vec(), b"fake-key".to_vec());
+}
+
+/// Spin up a TLS-enabled in-process Flight server that **requires** a
+/// client cert.  Generates a fresh CA, server cert, + client cert
+/// chain via rcgen — three certs, all with `localhost` SAN.
+async fn start_mtls_stub_server(
+    batch: Option<RecordBatch>,
+) -> (
+    String,
+    oneshot::Sender<()>,
+    Vec<u8>, // server CA pem (for the client to trust)
+    Vec<u8>, // client cert pem (for the client to present)
+    Vec<u8>, // client key pem
+) {
+    // Self-signed server cert.  rcgen's simple generator gives a
+    // fresh chain per call — fine for an isolated test process.
+    let server_cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("generate server cert");
+    let server_cert_pem = server_cert.cert.pem();
+    let server_key_pem = server_cert.signing_key.serialize_pem();
+
+    // Self-signed client cert (a separate identity).  In production
+    // the client cert would chain to a real CA; for the in-test
+    // server we treat the client cert itself as the trust anchor
+    // (a CA bundle of a single self-signed cert, which is how
+    // tonic accepts it).
+    let client_cert =
+        rcgen::generate_simple_self_signed(vec!["worker-test".to_string()]).expect("generate client cert");
+    let client_cert_pem = client_cert.cert.pem();
+    let client_key_pem = client_cert.signing_key.serialize_pem();
+
+    let server_identity = tonic::transport::Identity::from_pem(server_cert_pem.as_bytes(), server_key_pem.as_bytes());
+    // For mTLS: server demands client certs chaining to the client's
+    // own self-signed cert (acts as our trust root for the test).
+    let client_ca = tonic::transport::Certificate::from_pem(client_cert_pem.as_bytes());
+    let tls = tonic::transport::ServerTlsConfig::new()
+        .identity(server_identity)
+        .client_ca_root(client_ca);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local_addr");
+    let endpoint = format!("https://localhost:{}", addr.port());
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+    let last_ticket = Arc::new(tokio::sync::Mutex::new(None));
+    let svc = StubFlightShared {
+        response_batch: batch,
+        last_ticket,
+        required_token: None,
+    };
+
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        Server::builder()
+            .tls_config(tls)
+            .expect("server tls_config")
+            .add_service(FlightServiceServer::new(svc))
+            .serve_with_incoming_shutdown(incoming, async {
+                rx.await.ok();
+            })
+            .await
+            .expect("serve_with_incoming_shutdown");
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    (
+        endpoint,
+        tx,
+        server_cert_pem.into_bytes(),
+        client_cert_pem.into_bytes(),
+        client_key_pem.into_bytes(),
+    )
+}
+
+#[tokio::test]
+async fn connect_with_mtls_round_trips_against_demanding_server() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, server_ca, client_cert, client_key) = start_mtls_stub_server(Some(batch.clone())).await;
+
+    let tls = FlightTlsConfig::new()
+        .ca_certificate(server_ca)
+        .identity(client_cert, client_key)
+        .domain_name("localhost");
+    let resolver = FlightResolver::connect_with_tls(&endpoint, tls)
+        .await
+        .expect("connect_with mTLS");
+    let batches = resolver
+        .resolve("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("resolve over mTLS");
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].num_rows(), batch.num_rows());
+}
+
+#[tokio::test]
+async fn connect_with_mtls_rejected_when_client_cert_missing() {
+    let batch = sample_batch();
+    let (endpoint, _shutdown, server_ca, _client_cert, _client_key) = start_mtls_stub_server(Some(batch)).await;
+
+    // Trust the server's cert but DON'T present a client identity.
+    // The server (configured with `client_ca_root`) refuses the
+    // handshake.  tonic's `connect()` defers the full handshake
+    // until the first request, so the rejection surfaces on
+    // `resolve()` rather than `connect()`.
+    let tls = FlightTlsConfig::new()
+        .ca_certificate(server_ca)
+        .domain_name("localhost");
+    let resolver_result = FlightResolver::connect_with_tls(&endpoint, tls).await;
+    // Either connect or the first call fails — accept both shapes
+    // since different tonic versions surface the handshake error
+    // at different points.
+    match resolver_result {
+        Err(_) => {
+            // Handshake failed at connect time.  Acceptable.
+        }
+        Ok(resolver) => {
+            // Channel opened lazily; first call should fail.
+            let err = resolver
+                .resolve("noetl://execution/12345/result/x/y")
+                .await
+                .expect_err("expected first call to fail without client cert");
+            match err {
+                FlightError::Transport(_) | FlightError::Server(_) => {}
+                other => panic!("expected Transport/Server error, got {other:?}"),
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn connect_with_mtls_via_flight_config() {
+    // Same as the direct connect_with_tls path but via the unified
+    // `FlightConfig::new().tls(tls).bearer_token(t)` builder, to
+    // confirm mTLS composes with the Phase C2.3 auth surface.
+    let batch = sample_batch();
+    let (endpoint, _shutdown, server_ca, client_cert, client_key) = start_mtls_stub_server(Some(batch.clone())).await;
+
+    let tls = FlightTlsConfig::new()
+        .ca_certificate(server_ca)
+        .identity(client_cert, client_key)
+        .domain_name("localhost");
+    // No bearer needed (server isn't requiring it) but exercise the
+    // combined config shape anyway.
+    let cfg = FlightConfig::new().tls(tls);
+    let resolver = FlightResolver::connect_with(&endpoint, cfg)
+        .await
+        .expect("connect_with combined mTLS config");
+    let batches = resolver
+        .resolve("noetl://execution/12345/result/big_select/abcd1234")
+        .await
+        .expect("resolve via FlightConfig");
+    assert_eq!(batches.len(), 1);
+}


### PR DESCRIPTION
## Summary

Client-side half of R-2.3 Phase C2.4 — pairs with the server-side `NOETL_FLIGHT_CLIENT_CA` opt-in (noetl/noetl#648).  Adds the client-cert builder to `FlightTlsConfig` so the resolver can present a cert during the TLS handshake when the server demands mutual TLS.

Bumps `noetl-arrow-flight-client` to 0.5.0.

- New `FlightTlsConfig::identity(cert_pem, key_pem)` builder; composes cleanly with `ca_certificate` + `domain_name`.
- `to_tonic()` lazy-composes into `tonic::transport::Identity::from_pem`.

## Boundary discipline

Per `agents/rules/execution-model.md`, the client cert + key are business-logic credentials.  Callers (`noetl-tools` `ResultFetchTool` in the next PR) should resolve them from a worker-mounted k8s Secret (typical) or NoETL keychain alias rather than embedding PEM literals in playbook config.

## Test plan

- [x] 5 new tests (26 total): builder semantics + 3 integration tests against a new rcgen-generated mTLS-demanding stub server (round-trip with client cert, rejection without, integration via `FlightConfig`).
- [x] All 26 pass.  `cargo fmt` clean.

## Followup

Tracked under noetl/ai-meta#33:
- C2.4 noetl-tools wiring — `client_cert_path` + `client_key_path` on `ResultFetchConfig`.
- C2.5 — K8s manifests + Secret provisioning.
- C2.6 — Kind validation rig for the full TLS+auth+mTLS combo.

Refs noetl/ai-meta#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)