### PR TITLE
chore(release): publish noetl-events 0.1.0 + bump noetl-executor to 0.4.0 (EE-4 PR 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,59 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
+      # ---- noetl-events (workspace member) ----------------------------
+      # EE-4 PR 2 (noetl/ai-meta#49): the event-envelope crate must
+      # publish BEFORE noetl-executor because the executor's
+      # `events` module re-exports its surface via a path+version
+      # dep.  Once the crate ships its 0.1.0 here, noetl-server can
+      # adopt it directly in EE-4 PR 3 instead of carrying a
+      # hand-aligned EventRequest type.  Independent version (tracks
+      # the wire-envelope shape, not the CLI's release cadence).
+      - name: Get noetl-events version
+        id: events_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          EVENTS_VERSION=$(grep -E '^version = ' events/Cargo.toml | head -1 | cut -d'"' -f2)
+          echo "version=${EVENTS_VERSION}" >> "${GITHUB_OUTPUT}"
+      - name: Check noetl-events version on crates.io
+        id: events_check
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.events_version.outputs.version }}"
+          if curl -fsS -H "User-Agent: noetl-cli-release" "https://crates.io/api/v1/crates/noetl-events/${VERSION}" >/dev/null; then
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Publish noetl-events
+        if: ${{ env.CRATES_IO_TOKEN != '' && steps.events_check.outputs.already_published != 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_TOKEN }}
+        shell: bash
+        run: |
+          set +e
+          OUTPUT="$(cargo publish -p noetl-events 2>&1)"
+          STATUS=$?
+          set -e
+
+          echo "${OUTPUT}"
+
+          if [[ ${STATUS} -eq 0 ]]; then
+            exit 0
+          fi
+
+          if echo "${OUTPUT}" | grep -Eqi "already uploaded|already exists"; then
+            echo "noetl-events version already published; continuing."
+            exit 0
+          fi
+
+          exit ${STATUS}
+      - name: Skip noetl-events publish (already on crates.io)
+        if: ${{ steps.events_check.outputs.already_published == 'true' }}
+        run: echo "noetl-events version ${{ steps.events_version.outputs.version }} already on crates.io; skipping."
+
       # ---- noetl-executor (workspace member) --------------------------
       # R-1.2 PR-1: noetl-executor must publish before the noetl bin
       # because the bin depends on it from crates.io.  The executor's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/main.rs"
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.3" }
+noetl-executor = { path = "executor", version = "0.4" }
 
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "noetl-executor"
-version = "0.3.1"
+# 0.4.0 — EE-4 PR 2 (noetl/ai-meta#49 follow-up): the events module
+# now re-exports from the sibling `noetl-events` crate rather than
+# defining ExecutorEvent / EventSink inline.  Wire shape is
+# preserved verbatim (every test moved 1:1), but the dependency
+# graph changes (executor now pulls in noetl-events), so the bump
+# is minor-semver per the published-crate change-tracking rule.
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"


### PR DESCRIPTION
## Summary

Second of three rounds on EE-4 ([noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49) follow-up).  PR 1 ([#49](https://github.com/noetl/cli/pull/49)) extracted the \`noetl-events\` workspace crate as a self-contained refactor; this round prepares the publish path so the crate ships on crates.io and noetl-server can take a direct dep on it in EE-4 PR 3.

## Changes

* **\`events/Cargo.toml\`** stays at \`0.1.0\` — this is the first release of this crate.
* **\`executor/Cargo.toml\`** bumps from \`0.3.1\` → \`0.4.0\`.  Wire shape is preserved verbatim (every test moved 1:1) but the dependency graph changes (executor now pulls in \`noetl-events\` from crates.io after this release), so the bump is minor-semver per the published-crate change-tracking rule.
* **\`Cargo.toml\` (root)** — cli bin's \`noetl-executor = { path = \"executor\", version = \"0.3\" }\` bumps to \`\"0.4\"\` so the cli builds against the new executor.
* **\`.github/workflows/release.yml\`** — adds a \`noetl-events\` publish block positioned BEFORE the existing \`noetl-executor\` block.  Same shape as the \`arrow-cache\` / \`arrow-flight-client\` blocks: read the version, check if it's already on crates.io, skip if so, else \`cargo publish -p noetl-events\` and tolerate the already-uploaded race.

The serial order matters because \`noetl-executor\` depends on \`noetl-events\`.

## Verified locally

- \`cargo build --release -p noetl-events -p noetl-executor\` — clean.
- \`cargo publish --dry-run --allow-dirty -p noetl-events\` — packages cleanly, would upload \`0.1.0\`.
- \`cargo publish --dry-run --allow-dirty -p noetl-executor\` — fails with \`no matching package named noetl-events found\`.  **Expected**: \`noetl-events\` isn't on crates.io yet — the workflow's serial order publishes events first, which resolves the constraint for executor's publish step.

## Release flow once this merges

1. release-please opens a release PR (bumps the cli bin version).
2. Merging that triggers \`.github/workflows/release.yml\`.
3. \`publish-crate\` job publishes \`noetl-events 0.1.0\`, then \`noetl-executor 0.4.0\`, then \`noetl-arrow-cache\` / \`-flight-client\` (unchanged), then the noetl bin.
4. **EE-4 PR 3** (separate, on noetl/server) then adopts \`noetl-events\` as a direct dep + replaces the hand-aligned \`EventRequest\` with a thin wrapper around \`noetl_events::ExecutorEvent\`.

## Test plan

- [x] \`cargo build --release -p noetl-events -p noetl-executor\` clean
- [x] \`cargo publish --dry-run --allow-dirty -p noetl-events\` packages cleanly
- [ ] Reviewers: confirm the workflow-block placement (events MUST publish before executor); confirm the minor-semver bump on executor is the right step for \"dependency-graph change but no public-API change.\"
- [ ] After merge: watch the release workflow to confirm \`noetl-events 0.1.0\` + \`noetl-executor 0.4.0\` both land on crates.io.

Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)