### PR TITLE
executor: propagate ToolResult.pending_callback (noetl-tools 2.21 compat, 0.4.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2926,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "noetl-tools"
-version = "2.16.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdadc2ecd85fbaf7d2d1653ff77a00e595f65d375c01aca6a1a10ae9aa7ddbc7"
+checksum = "daaae519910f9c12bd6784b8fd9c1c3c2584b39bbe8734d07d3d47143c3b8334"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "noetl-executor"
-# 0.4.0 — EE-4 PR 2 (noetl/ai-meta#49 follow-up): the events module
-# now re-exports from the sibling `noetl-events` crate rather than
-# defining ExecutorEvent / EventSink inline.  Wire shape is
-# preserved verbatim (every test moved 1:1), but the dependency
-# graph changes (executor now pulls in noetl-events), so the bump
-# is minor-semver per the published-crate change-tracking rule.
-version = "0.4.0"
+# 0.4.1 — noetl/ai-meta#43 Round 4 follow-up.  noetl-tools 2.21
+# added a new `pending_callback: Option<bool>` field on
+# `ToolResult` (the marker the new `Tool::Container` sets to
+# signal that `call.done` arrives asynchronously via a server-side
+# callback path).  Adding a non-Default field to a public struct
+# breaks struct-literal call sites — the bridge's
+# `reshape_duckdb_result` reconstructs a `ToolResult` by-field, so
+# this patch bump just propagates `result.pending_callback` through
+# the bridge unchanged.  No API surface change on the executor
+# itself, hence patch-level rather than minor.
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"
@@ -66,7 +70,7 @@ rhai = { version = "1.18", features = ["sync"] }
 # Subsequent sub-PRs (PR-2c-2 onwards per Strategy B) replace one
 # inline tool implementation in playbook_runner.rs at a time so
 # semantic differences surface incrementally instead of all at once.
-noetl-tools = "2.8.7"
+noetl-tools = "2.21"
 
 # GCS uploads in `tools_bridge::gcs_upload` (R-3 GCS sink migration,
 # noetl/ai-meta#31).  The `gcp` feature pulls in

--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -575,6 +575,10 @@ fn reshape_duckdb_result(result: ToolResult) -> Result<BridgeOutcome> {
         stderr: result.stderr,
         exit_code: result.exit_code,
         duration_ms: result.duration_ms,
+        // noetl-tools 2.21 added this marker field; the executor
+        // bridge has nothing to attach here (DuckDB doesn't dispatch
+        // async work), so it always falls through as `None`.
+        pending_callback: result.pending_callback,
     })
 }
 
@@ -1395,6 +1399,7 @@ mod tests {
             stderr: None,
             exit_code: Some(1),
             duration_ms: Some(5),
+            pending_callback: None,
         };
         result.exit_code = Some(1);
         let outcome = reshape_http_result(result).unwrap();


### PR DESCRIPTION
## Summary

- Patch `noetl-executor` to compile against `noetl-tools` 2.21.0,
  which added a non-Default `ToolResult.pending_callback:
  Option<bool>` field as part of noetl/ai-meta#43 Round 3 (Container
  Tool callback).
- Bridge propagates the marker unchanged through
  `reshape_duckdb_result`; HTTP test fixture pins
  `pending_callback: None`.
- `noetl-tools` dep bumped to `^2.21`; crate bumped to 0.4.1 (patch
  level — no executor API surface change).

## Why

Without this, downstream consumers (noetl-worker bumping
`noetl-tools = "2.21"` to wire the worker-side
`pending_callback` adoption follow-up in noetl/worker#59) fail
with:

```
error[E0063]: missing field `pending_callback` in initializer of `ToolResult`
 --> noetl-executor-0.4.0/src/tools_bridge.rs:570:23
```

## Test plan

- [x] `cargo build -p noetl-executor --lib` clean.
- [x] `cargo test -p noetl-executor --lib` — 102/0.
- [ ] After merge: publish noetl-executor 0.4.1 to crates.io so
      noetl/worker#59 can adopt.

Closes noetl/cli#55
Refs noetl/ai-meta#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)