### PR TITLE
chore(deps): bump noetl-tools 2.21 → 3, noetl-executor 0.4.1 → 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2926,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "noetl-tools"
-version = "2.21.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaae519910f9c12bd6784b8fd9c1c3c2584b39bbe8734d07d3d47143c3b8334"
+checksum = "37439e23c759ec87a9221614cfe2cd02a216637721cba0408e68884d9b27a3c3"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/main.rs"
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.4" }
+noetl-executor = { path = "executor", version = "0.5" }
 
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
 name = "noetl-executor"
-# 0.4.1 — noetl/ai-meta#43 Round 4 follow-up.  noetl-tools 2.21
-# added a new `pending_callback: Option<bool>` field on
-# `ToolResult` (the marker the new `Tool::Container` sets to
-# signal that `call.done` arrives asynchronously via a server-side
-# callback path).  Adding a non-Default field to a public struct
-# breaks struct-literal call sites — the bridge's
-# `reshape_duckdb_result` reconstructs a `ToolResult` by-field, so
-# this patch bump just propagates `result.pending_callback` through
-# the bridge unchanged.  No API surface change on the executor
-# itself, hence patch-level rather than minor.
-version = "0.4.1"
+# 0.5.0 — noetl/ai-meta#77 (explicit input:/set: forward-only data
+# binding).  noetl-tools v3.0.0 is a breaking change: TaskSequenceTool
+# replaces _prev/_results injection with explicit set:/input: forward-
+# only data binding.  Bumped from noetl-tools "2.21" → "3" so both the
+# CLI and noetl-worker resolve to the same major version.
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"
@@ -70,7 +65,7 @@ rhai = { version = "1.18", features = ["sync"] }
 # Subsequent sub-PRs (PR-2c-2 onwards per Strategy B) replace one
 # inline tool implementation in playbook_runner.rs at a time so
 # semantic differences surface incrementally instead of all at once.
-noetl-tools = "2.21"
+noetl-tools = "3"
 
 # GCS uploads in `tools_bridge::gcs_upload` (R-3 GCS sink migration,
 # noetl/ai-meta#31).  The `gcp` feature pulls in


### PR DESCRIPTION
## Summary

- Bumps `noetl-tools` from `"2.21"` to `"3"` in the executor crate
- Bumps `noetl-executor` version from `0.4.1` to `0.5.0` (semver minor → breaking dep change)
- Updates `Cargo.lock` to resolve `noetl-tools v3.0.0` from crates.io
- Updates workspace-level `noetl-executor` version constraint to `"0.5"`

noetl-tools v3.0.0 (noetl/tools#45) is a breaking change: `TaskSequenceTool` replaces `_prev`/`_results` injection with explicit `set:`/`input:` forward-only data binding. All e2e fixtures migrated in noetl/e2e#35.

## Test plan

- [x] `cargo build --release` passes (one dead_code warning on existing code, unrelated)
- [ ] Release pipeline publishes noetl-executor 0.5.0 to crates.io
- [ ] noetl-worker adopts noetl-executor 0.5 + noetl-tools 3 from crates.io

Refs noetl/ai-meta#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)