### PR TITLE
docs(cli): fix get-credential example to use --include-data flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -501,7 +501,7 @@ enum GetResource {
     /// Get credential details with optional data inclusion
     /// Examples:
     ///     noetl get credential my-db-creds
-    ///     noetl get credential google_oauth --include_data=false
+    ///     noetl get credential google_oauth --include-data=false
     ///     noetl --host=localhost --port=8082 get credential aws-credentials
     #[command(verbatim_doc_comment)]
     Credential {


### PR DESCRIPTION
## What

`src/main.rs:504` — the `get credential` doc-comment example showed
`--include_data=false`, but clap renders the long flag as
`--include-data` (underscores become hyphens). The example as written
is rejected:

```
error: unexpected argument '--include_data' found
  tip: a similar argument exists: '--include-data'
```

Change the example to the actual flag: `--include-data=false`.

## Why

Trivial doc-comment fix surfaced while verifying CLI credential
registration against the wallet-era server. No behavior change — the
flag definition (`#[arg(long, default_value_t = true)]`) is untouched;
only the example text in the help doc-comment is corrected.

## Validation

`cargo build --bin noetl` — compiles clean (only the pre-existing
`extract_auth0_tenant_from_domain` dead-code warning).

Housekeeping doc fix; no ai-task issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)