### PR TITLE
feat: noetl subscribe — local-mode subscription listener (RFC #90 Phase 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,7 +2132,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2306,15 +2321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2394,22 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
+]
+
+[[package]]
+name = "kafka"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054ba4edcb4dcda4209e138c7e88caf26d4a325b3db76fbdb6ca5eecc23e426"
+dependencies = [
+ "byteorder",
+ "crc",
+ "flate2",
+ "fnv",
+ "ref_slice",
+ "thiserror 1.0.69",
+ "tracing",
+ "twox-hash",
 ]
 
 [[package]]
@@ -2814,6 +2836,7 @@ name = "noetl"
 version = "4.10.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
  "chrono",
  "clap",
@@ -2822,7 +2845,9 @@ dependencies = [
  "dotenvy",
  "duckdb",
  "nix 0.29.0",
+ "noetl-events",
  "noetl-executor",
+ "noetl-tools",
  "rand 0.8.6",
  "ratatui",
  "regex",
@@ -2926,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "noetl-tools"
-version = "3.0.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37439e23c759ec87a9221614cfe2cd02a216637721cba0408e68884d9b27a3c3"
+checksum = "3c16265c993f0c46c21cc70cc9fa8b4cf71e032429a4a6c1f67d3f35a01c2b69"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",
@@ -2944,6 +2969,7 @@ dependencies = [
  "futures",
  "gcp_auth",
  "k8s-openapi",
+ "kafka",
  "kube",
  "minijinja",
  "noetl-arrow-flight-client 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2952,6 +2978,7 @@ dependencies = [
  "rhai",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3457,7 +3484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3744,6 +3771,12 @@ dependencies = [
  "libredox",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "ref_slice"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ed1d73fb92eba9b841ba2aef69533a060ccc0d3ec71c90aeda5996d4afb7a9"
 
 [[package]]
 name = "regex"
@@ -5117,6 +5150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.6",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5505,7 +5549,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5533,7 +5577,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -5543,23 +5587,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -5574,32 +5605,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5619,24 +5628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,19 @@ path = "src/main.rs"
 # so this dependency can be satisfied from crates.io.
 noetl-executor = { path = "executor", version = "0.5" }
 
+# noetl/ai-meta#90 Phase 6 — the `noetl subscribe` local-mode listener
+# reuses the same source clients (`build_source`), header-directive engine,
+# and store-and-forward spool engine the in-cluster worker runtime uses, so
+# the event model is identical across CLI-local / in-cluster / Cloud Run.
+# `noetl-tools` "3" resolves to the published crate (v3.5.0+) that carries
+# the Phase 1–5 `tools::source` + `spool` surface; default features pull in
+# the pubsub + kafka + gcs source/backends.  `noetl-events` is the shared
+# `EventSink` trait + `ExecutorEvent` envelope the local `FileEventSink`
+# implements (same wire shape as the worker's NATS/HTTP sinks).
+noetl-tools = "3"
+noetl-events = { path = "events", version = "0.1.0" }
+async-trait = "0.1"
+
 clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/examples/subscribe/orders_spool_subscription.yaml
+++ b/examples/subscribe/orders_spool_subscription.yaml
@@ -1,0 +1,50 @@
+# `noetl subscribe` example — local listener WITH a local_disk store-and-forward
+# spool (RFC noetl/ai-meta#90 Phase 6, §8.6).
+#
+# When the declared downstream (`warehouse`) is unreachable, the circuit opens
+# and each message is buffered durably to the local_disk spool instead of being
+# dropped; when the downstream recovers, the spool drains and replays the
+# buffered messages in receive order (idempotent, dead-lettered after
+# max_replay_attempts).  The whole outage is reconstructable from the JSONL
+# event trail (subscription.circuit.opened / message.spooled / circuit.closed /
+# spool.draining / message.replayed).
+#
+#   noetl subscribe examples/subscribe/orders_spool_subscription.yaml \
+#     --events ./spool-trail.jsonl --spool-dir ./spooldir
+#
+# The spool backend is forced to `local_disk` in local mode regardless of what
+# the spec declares (§8.6) — a spec authored for the in-cluster `nats_object`
+# / `gcs` backend runs locally unchanged.
+apiVersion: noetl.io/v1
+kind: Subscription
+metadata:
+  name: orders_spool_local
+spec:
+  source: nats
+  url: nats://localhost:4222
+  user: noetl
+  password: noetl
+  stream: ORDERS_LOCAL
+  consumer: orders-local
+  runtime:
+    batch: 50
+    timeout_ms: 2000
+  dispatch:
+    playbook: ./process_order.yaml
+    payload_from: message.json
+    execution_pool: warehouse
+  spool:
+    mode: buffer_and_ack
+    backend: local_disk
+    ordering: global
+    circuit:
+      trip_after: 1
+      probe_after_ms: 500
+      probe_interval_ms: 400
+      downstream:
+        - name: warehouse
+          type: tcp
+          target: "127.0.0.1:19099"
+    drain:
+      max_replay_attempts: 5
+      on_recovery: ordered_then_live

--- a/examples/subscribe/orders_subscription.yaml
+++ b/examples/subscribe/orders_subscription.yaml
@@ -1,0 +1,30 @@
+# `noetl subscribe` example — pure-local NATS listener (RFC noetl/ai-meta#90 Phase 6).
+#
+# Holds a NATS JetStream pull consumer open in-process and runs the target
+# playbook locally for each message, emitting an event-sourced JSONL trail.
+#
+#   # prepare a stream + durable consumer + publish a few messages, then:
+#   noetl subscribe examples/subscribe/orders_subscription.yaml \
+#     --events ./orders-trail.jsonl --max-messages 5
+#
+# The source's credentials are explicit `user` / `password` fields (NATS does
+# not honor user:pass embedded in the URL when connecting via ConnectOptions);
+# alternatively pass `auth: <alias>` + `--credential cred.json`.
+apiVersion: noetl.io/v1
+kind: Subscription
+metadata:
+  name: orders_local
+spec:
+  source: nats
+  url: nats://localhost:4222
+  user: noetl
+  password: noetl
+  stream: ORDERS_LOCAL
+  consumer: orders-local
+  runtime:
+    batch: 50
+    timeout_ms: 3000
+  dispatch:
+    playbook: ./process_order.yaml
+    payload_from: message.json
+    execution_pool: local

--- a/examples/subscribe/process_order.yaml
+++ b/examples/subscribe/process_order.yaml
@@ -1,0 +1,24 @@
+# Target playbook run in-process for each subscription message.
+#
+# The message body is merged to the top level of the workload, so a JSON
+# message `{"order_id": 1, "amount": 10, "region": "us"}` exposes
+# `{{ workload.order_id }}` etc.  The full normalized envelope is also available
+# under `{{ workload.message }}` (id / data / headers / attributes / metadata).
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: process_order_local
+workload:
+  order_id: "0"
+  amount: "0"
+  region: "unknown"
+workflow:
+  - step: start
+    desc: "Process one order received from the subscription"
+    next:
+      - step: log_order
+  - step: log_order
+    tool:
+      kind: shell
+      cmds:
+        - echo "processed order_id={{ workload.order_id }} amount={{ workload.amount }} region={{ workload.region }}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod playbook_runner;
+mod subscribe;
 
 use anyhow::{bail, Context as AnyhowContext, Result};
 use base64::prelude::*;
@@ -148,6 +149,63 @@ enum Commands {
         /// Emit only JSON response (distributed runtime)
         #[arg(short, long)]
         json: bool,
+    },
+    /// Run a kind:Subscription listener standalone in local mode (no k8s, no server)
+    ///
+    /// Holds the subscription's source (NATS / Pub/Sub / Kafka) open
+    /// in-process and turns each received message into one local playbook run
+    /// (the pure-local default) or a POST /api/execute (--dispatch server),
+    /// honoring header directives and a local_disk store-and-forward spool.
+    /// Emits the SAME event envelope the in-cluster runtime emits — to a local
+    /// JSONL FileEventSink — so the run produces a replayable event-sourced
+    /// log on disk.  (RFC noetl/ai-meta#90 Phase 6.)
+    ///
+    /// Examples:
+    ///     noetl subscribe ./subscriptions/orders.yaml
+    ///     noetl subscribe orders.yaml --events ./trail.jsonl --once
+    ///     noetl subscribe iot.yaml --max-messages 6 --spool-dir /tmp/spool
+    ///     noetl subscribe orders.yaml --dispatch server --server-url http://localhost:8082
+    #[command(verbatim_doc_comment)]
+    Subscribe {
+        /// Path to a kind:Subscription YAML spec
+        #[arg(value_name = "SPEC")]
+        reference: String,
+
+        /// Dispatch model: local (in-process PlaybookRunner) or server (POST /api/execute)
+        #[arg(long, default_value = "local")]
+        dispatch: String,
+
+        /// Server URL for --dispatch server (defaults to the resolved base URL)
+        #[arg(long)]
+        server_url: Option<String>,
+
+        /// JSONL event-sink path (defaults to ./<name>-events.jsonl)
+        #[arg(long, value_name = "PATH")]
+        events: Option<PathBuf>,
+
+        /// Override the local_disk spool directory
+        #[arg(long, value_name = "DIR")]
+        spool_dir: Option<String>,
+
+        /// Base dir for resolving relative dispatch.playbook refs (default: spec dir)
+        #[arg(long, value_name = "DIR")]
+        playbook_dir: Option<PathBuf>,
+
+        /// Local credential JSON file injected for the source's auth alias
+        #[arg(long, value_name = "FILE")]
+        credential: Option<PathBuf>,
+
+        /// Stop after N handled messages (0 = run continuously)
+        #[arg(long, default_value_t = 0)]
+        max_messages: u64,
+
+        /// Drain the source once then exit
+        #[arg(long)]
+        once: bool,
+
+        /// Verbose dispatch output
+        #[arg(short, long)]
+        verbose: bool,
     },
     /// Legacy run command (deprecated, use 'exec')
     #[command(name = "run-legacy", hide = true)]
@@ -2271,6 +2329,41 @@ async fn main() -> Result<()> {
                     std::process::exit(1);
                 }
             }
+        }
+        Some(Commands::Subscribe {
+            reference,
+            dispatch,
+            server_url,
+            events,
+            spool_dir,
+            playbook_dir,
+            credential,
+            max_messages,
+            once,
+            verbose,
+        }) => {
+            // Default the server URL (for --dispatch server) to the resolved
+            // base URL when not given explicitly.
+            let server_url = server_url.or_else(|| {
+                if dispatch == "server" {
+                    Some(base_url.clone())
+                } else {
+                    None
+                }
+            });
+            subscribe::run(subscribe::SubscribeArgs {
+                reference,
+                dispatch,
+                server_url,
+                events,
+                spool_dir,
+                playbook_dir,
+                credential,
+                max_messages,
+                once,
+                verbose,
+            })
+            .await?;
         }
         Some(Commands::RunLegacy {
             reference,

--- a/src/subscribe/dispatch.rs
+++ b/src/subscribe/dispatch.rs
@@ -1,0 +1,345 @@
+//! Local dispatch model for `noetl subscribe` (RFC #90 Phase 6, §5.3).
+//!
+//! RFC §5.3 spells out what a received message *does* in pure-local mode:
+//!
+//! > For each message runs the `dispatch.playbook` **in-process** (reusing the
+//! > local `PlaybookRunner`), **or** posts to a configured `server_url`.
+//!
+//! So the default — the "pure local" mode the phase is about — runs the target
+//! playbook **in-process** with the message as its workload, via the same
+//! [`crate::playbook_runner::PlaybookRunner`] `noetl exec --runtime local`
+//! uses.  No server, no NATS-dispatch.  The `--dispatch server` variant (or a
+//! `--server-url`) instead POSTs `/api/execute` to a control plane, keeping
+//! the event model identical — only the dispatch sink differs.
+//!
+//! Both produce a [`DispatchResult`] carrying the per-message child
+//! `execution_id` and terminal status, which the runtime turns into the
+//! `playbook.started` / `playbook.completed` event-sourced pair (RFC §3.4).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use noetl_tools::tools::source::{DispatchPlan, PolledMessage};
+
+use crate::subscribe::sink::LocalIdGen;
+
+/// Outcome of dispatching one message.
+#[derive(Debug, Clone)]
+pub struct DispatchResult {
+    /// The per-message child execution id (generated app-side for local
+    /// dispatch; returned by the server for `--dispatch server`).
+    pub execution_id: i64,
+    /// Terminal status — `"COMPLETED"` / `"FAILED"`.
+    pub status: String,
+    /// Error detail when the run failed.
+    pub error: Option<String>,
+}
+
+impl DispatchResult {
+    pub fn ok(&self) -> bool {
+        self.status == "COMPLETED"
+    }
+}
+
+/// Turns one polled message + its resolved directive plan into an execution.
+#[async_trait]
+pub trait Dispatcher: Send + Sync {
+    /// Dispatch `msg` to `playbook` on the resolved `pool`.  The
+    /// `payload_from` selects which part of the normalized envelope becomes
+    /// the playbook body (`message.json` default).
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        playbook: &str,
+        pool: Option<&str>,
+        msg: &PolledMessage,
+        plan: &DispatchPlan,
+        payload_from: &str,
+        subscription: &str,
+        source: &str,
+    ) -> Result<DispatchResult>;
+
+    /// Human label for the report (`"in-process"` / `"server <url>"`).
+    fn label(&self) -> String;
+}
+
+// ---------------------------------------------------------------------------
+// Local in-process dispatcher (the pure-local default)
+// ---------------------------------------------------------------------------
+
+/// Runs the target playbook in-process via [`crate::playbook_runner`].
+pub struct LocalDispatcher {
+    /// Base dir for resolving relative `dispatch.playbook` refs (defaults to
+    /// the subscription spec's directory).
+    playbook_dir: PathBuf,
+    verbose: bool,
+    ids: Arc<LocalIdGen>,
+}
+
+impl LocalDispatcher {
+    pub fn new(playbook_dir: PathBuf, verbose: bool, ids: Arc<LocalIdGen>) -> Self {
+        Self {
+            playbook_dir,
+            verbose,
+            ids,
+        }
+    }
+
+    fn resolve_path(&self, playbook: &str) -> PathBuf {
+        let p = PathBuf::from(playbook);
+        if p.is_absolute() || p.exists() {
+            p
+        } else {
+            self.playbook_dir.join(playbook)
+        }
+    }
+}
+
+#[async_trait]
+impl Dispatcher for LocalDispatcher {
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        playbook: &str,
+        _pool: Option<&str>,
+        msg: &PolledMessage,
+        plan: &DispatchPlan,
+        payload_from: &str,
+        subscription: &str,
+        source: &str,
+    ) -> Result<DispatchResult> {
+        let execution_id = self.ids.next();
+        let path = self.resolve_path(playbook);
+        if !path.exists() {
+            anyhow::bail!(
+                "dispatch.playbook '{}' not found (resolved to {}); local dispatch needs a file path",
+                playbook,
+                path.display()
+            );
+        }
+        let envelope = build_envelope(msg, payload_from, plan, subscription, source);
+        let variables = envelope_to_variables(&envelope);
+        let verbose = self.verbose;
+
+        // PlaybookRunner is synchronous + CPU/IO-bound; run it off the async
+        // executor so the drain loop stays responsive.
+        let outcome = tokio::task::spawn_blocking(move || {
+            crate::playbook_runner::PlaybookRunner::new(path)
+                .with_variables(variables)
+                .with_verbose(verbose)
+                .with_quiet(true)
+                .run()
+        })
+        .await
+        .context("local dispatch task panicked")?;
+
+        match outcome {
+            Ok(run) => Ok(DispatchResult {
+                execution_id,
+                status: if run.status == "ok" { "COMPLETED".into() } else { "FAILED".into() },
+                error: run.error,
+            }),
+            Err(e) => Ok(DispatchResult {
+                execution_id,
+                status: "FAILED".into(),
+                error: Some(format!("{e:#}")),
+            }),
+        }
+    }
+
+    fn label(&self) -> String {
+        "in-process (PlaybookRunner)".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server dispatcher (the `--dispatch server` / `--server-url` variant)
+// ---------------------------------------------------------------------------
+
+/// POSTs `/api/execute` to a control plane.  Keeps the event model identical
+/// to the in-cluster runtime — the server records the run; the local trail
+/// still captures the ingress + dispatch records.
+pub struct ServerDispatcher {
+    client: reqwest::Client,
+    server_url: String,
+}
+
+impl ServerDispatcher {
+    pub fn new(server_url: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            server_url: server_url.trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl Dispatcher for ServerDispatcher {
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        playbook: &str,
+        pool: Option<&str>,
+        msg: &PolledMessage,
+        plan: &DispatchPlan,
+        payload_from: &str,
+        subscription: &str,
+        source: &str,
+    ) -> Result<DispatchResult> {
+        let envelope = build_envelope(msg, payload_from, plan, subscription, source);
+        let mut body = serde_json::json!({
+            "path": playbook,
+            "workload": envelope,
+        });
+        if let Some(p) = pool {
+            body["execution_pool"] = serde_json::json!(p);
+        }
+        let resp = self
+            .client
+            .post(format!("{}/api/execute", self.server_url))
+            .json(&body)
+            .send()
+            .await
+            .context("POST /api/execute")?;
+        let status = resp.status();
+        let json: serde_json::Value = resp.json().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("server /api/execute returned {status}: {json}");
+        }
+        let execution_id = json
+            .get("execution_id")
+            .and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+            .unwrap_or(0);
+        Ok(DispatchResult {
+            execution_id,
+            status: "COMPLETED".into(),
+            error: None,
+        })
+    }
+
+    fn label(&self) -> String {
+        format!("server {}", self.server_url)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope construction (shared, mirrors the worker's build_payload)
+// ---------------------------------------------------------------------------
+
+/// Build the per-message execution payload, identical in shape to the worker
+/// runtime's `build_payload` so a playbook reads the same envelope whether it
+/// ran in-cluster or locally.  The full normalized message rides under
+/// `message`; the `payload_from` selection is merged to the top level (object
+/// body) or placed under `body` (scalar); idempotency key + content type from
+/// directives ride alongside.
+pub fn build_envelope(
+    msg: &PolledMessage,
+    payload_from: &str,
+    plan: &DispatchPlan,
+    subscription: &str,
+    source: &str,
+) -> serde_json::Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "message".to_string(),
+        serde_json::to_value(msg).unwrap_or(serde_json::Value::Null),
+    );
+    payload.insert("subscription".to_string(), serde_json::json!(subscription));
+    payload.insert("source".to_string(), serde_json::json!(source));
+
+    let primary = match payload_from {
+        "message.attributes" => msg.attributes.clone(),
+        "message.body" => match &msg.data {
+            serde_json::Value::String(s) => serde_json::Value::String(s.clone()),
+            other => serde_json::Value::String(other.to_string()),
+        },
+        _ => msg.data.clone(),
+    };
+    match primary {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                payload.entry(k).or_insert(v);
+            }
+        }
+        other => {
+            payload.insert("body".to_string(), other);
+        }
+    }
+    if let Some(k) = plan.idempotency_key.as_ref() {
+        payload.insert("idempotency_key".to_string(), serde_json::json!(k));
+    }
+    if let Some(c) = plan.content_type.as_ref() {
+        payload.insert("content_type".to_string(), serde_json::json!(c));
+    }
+    serde_json::Value::Object(payload)
+}
+
+/// Flatten the envelope object into the string-keyed variables
+/// [`crate::playbook_runner::PlaybookRunner`] accepts.  PlaybookRunner prefixes
+/// each key with `workload.`, so a top-level scalar field `order_id` resolves
+/// as `{{ workload.order_id }}`; nested objects (`message`, the merged body)
+/// are passed as compact JSON strings so `{{ workload.message }}` is available
+/// as a string the playbook can re-parse.
+pub fn envelope_to_variables(envelope: &serde_json::Value) -> HashMap<String, String> {
+    let mut vars = HashMap::new();
+    if let Some(map) = envelope.as_object() {
+        for (k, v) in map {
+            let s = match v {
+                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::Null => String::new(),
+                other => other.to_string(),
+            };
+            vars.insert(k.clone(), s);
+        }
+    }
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn msg(data: serde_json::Value, headers: serde_json::Value) -> PolledMessage {
+        PolledMessage {
+            id: "stream:7".to_string(),
+            data,
+            headers: headers.as_object().cloned().unwrap_or_default(),
+            attributes: json!({}),
+            metadata: json!({}),
+            ack_id: None,
+        }
+    }
+
+    #[test]
+    fn envelope_merges_json_body_to_top_level() {
+        let m = msg(json!({ "order_id": 42, "amount": 9 }), json!({}));
+        let env = build_envelope(&m, "message.json", &DispatchPlan::default(), "subs/orders", "nats");
+        assert_eq!(env["order_id"], 42);
+        assert_eq!(env["message"]["data"]["order_id"], 42);
+        assert_eq!(env["subscription"], "subs/orders");
+        assert_eq!(env["source"], "nats");
+    }
+
+    #[test]
+    fn envelope_scalar_body_under_body_key() {
+        let m = msg(json!("raw"), json!({}));
+        let env = build_envelope(&m, "message.json", &DispatchPlan::default(), "p", "nats");
+        assert_eq!(env["body"], "raw");
+    }
+
+    #[test]
+    fn variables_flatten_scalars_and_stringify_nested() {
+        let m = msg(json!({ "order_id": 42, "nested": { "x": 1 } }), json!({}));
+        let env = build_envelope(&m, "message.json", &DispatchPlan::default(), "subs/orders", "nats");
+        let vars = envelope_to_variables(&env);
+        assert_eq!(vars.get("order_id").map(String::as_str), Some("42"));
+        assert_eq!(vars.get("subscription").map(String::as_str), Some("subs/orders"));
+        // nested object is passed as compact JSON for re-parse.
+        assert!(vars.get("message").unwrap().contains("\"order_id\":42"));
+        assert!(vars.get("nested").unwrap().contains("\"x\":1"));
+    }
+}

--- a/src/subscribe/mod.rs
+++ b/src/subscribe/mod.rs
@@ -1,0 +1,198 @@
+//! `noetl subscribe` — run a `kind: Subscription` listener standalone in local
+//! mode (RFC #90 Phase 6, §5.3).
+//!
+//! No Kubernetes, no NATS-dispatch server is required for the listening
+//! itself: this reuses the **same** `SourceClient` poll + header-directive
+//! engine + store-and-forward spool engine the in-cluster worker runtime uses
+//! (`noetl_tools::tools::source` + `noetl_tools::spool`), and emits the **same**
+//! `ExecutorEvent` envelope — to a local `FileEventSink` (JSONL) — so a local
+//! run produces a replayable event-sourced log identical in shape to the
+//! in-cluster / Cloud Run trail.  Per RFC §5.3 a received message either runs
+//! the target playbook **in-process** (the pure-local default, via
+//! `PlaybookRunner`) or POSTs `/api/execute` when `--dispatch server` is set.
+
+mod dispatch;
+mod runtime;
+mod sink;
+mod spec;
+mod spool;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use noetl_events::EventSink;
+
+use dispatch::{Dispatcher, LocalDispatcher, ServerDispatcher};
+use runtime::{LocalRuntime, StopWhen};
+use sink::{FileEventSink, LocalIdGen};
+use spec::parse_spec;
+
+/// Parsed `noetl subscribe` invocation (built from the clap subcommand).
+#[derive(Debug, Clone)]
+pub struct SubscribeArgs {
+    /// Path to a `kind: Subscription` YAML spec.
+    pub reference: String,
+    /// Dispatch model: `local` (in-process) or `server` (`POST /api/execute`).
+    pub dispatch: String,
+    /// Server URL for `--dispatch server` (defaults to the resolved base URL).
+    pub server_url: Option<String>,
+    /// JSONL event-sink path (defaults to `./<name>-events.jsonl`).
+    pub events: Option<PathBuf>,
+    /// Override the spool dir (`local_disk` backend path).
+    pub spool_dir: Option<String>,
+    /// Base dir for resolving relative `dispatch.playbook` refs (defaults to
+    /// the spec's directory).
+    pub playbook_dir: Option<PathBuf>,
+    /// Local credential JSON file injected for the source's `auth:` alias.
+    pub credential: Option<PathBuf>,
+    /// Stop after N handled messages (`0` = run continuously).
+    pub max_messages: u64,
+    /// Drain the source once then exit.
+    pub once: bool,
+    /// Verbose dispatch output.
+    pub verbose: bool,
+}
+
+/// Entry point dispatched from `main`.
+pub async fn run(args: SubscribeArgs) -> Result<()> {
+    // A long-lived listener needs its diagnostics visible: install a tracing
+    // subscriber (stderr) honoring `RUST_LOG` (default `info`).  `try_init`
+    // is a no-op if the process already installed one.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+
+    // 1. Load + parse the subscription spec.
+    let spec_path = PathBuf::from(&args.reference);
+    let yaml_str = std::fs::read_to_string(&spec_path)
+        .with_context(|| format!("read subscription spec {}", spec_path.display()))?;
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&yaml_str)
+        .with_context(|| format!("parse subscription YAML {}", spec_path.display()))?;
+
+    let sub_name = yaml
+        .get("metadata")
+        .and_then(|m| m.get("name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            spec_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "subscription".to_string())
+        });
+
+    let parsed = parse_spec(&yaml, &sub_name, args.spool_dir.as_deref())?;
+
+    // 2. Build the local FileEventSink (the replayable trail).
+    let events_path = args.events.clone().unwrap_or_else(|| {
+        PathBuf::from(format!("{}-events.jsonl", slug(&sub_name)))
+    });
+    let sink: Arc<dyn EventSink> =
+        Arc::new(FileEventSink::create(&events_path, true).context("create event sink")?);
+
+    // 3. Build the dispatcher per the RFC §5.3 local dispatch model.
+    let ids = Arc::new(LocalIdGen::new());
+    let dispatcher: Arc<dyn Dispatcher> = match args.dispatch.as_str() {
+        "server" => {
+            let url = args
+                .server_url
+                .clone()
+                .context("--dispatch server requires --server-url")?;
+            Arc::new(ServerDispatcher::new(url))
+        }
+        "local" => {
+            let playbook_dir = args.playbook_dir.clone().unwrap_or_else(|| {
+                spec_path
+                    .parent()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("."))
+            });
+            Arc::new(LocalDispatcher::new(playbook_dir, args.verbose, ids.clone()))
+        }
+        other => anyhow::bail!("unknown --dispatch '{other}' (use 'local' or 'server')"),
+    };
+
+    // 4. Resolve a local credential for the source's auth alias (no server call).
+    let credential = match (&parsed.auth_alias, &args.credential) {
+        (Some(alias), Some(file)) => {
+            let json = std::fs::read_to_string(file)
+                .with_context(|| format!("read credential file {}", file.display()))?;
+            Some((alias.clone(), json))
+        }
+        _ => None,
+    };
+
+    // 5. Stop condition.
+    let stop = if args.once {
+        StopWhen::OneDrain
+    } else if args.max_messages > 0 {
+        StopWhen::Handled(args.max_messages)
+    } else {
+        StopWhen::Never
+    };
+
+    eprintln!("🔔 noetl subscribe — {} (source: {})", sub_name, parsed.source_cfg.source);
+    eprintln!("   dispatch : {}", dispatcher.label());
+    eprintln!("   events   : {}", events_path.display());
+    if parsed.spool.buffers() {
+        eprintln!(
+            "   spool    : local_disk {} (mode: {})",
+            parsed.spool.path.as_deref().unwrap_or("?"),
+            parsed.spool.mode.as_str()
+        );
+    }
+
+    // 6. Run with a Ctrl-C / SIGTERM shutdown.
+    let rt = LocalRuntime::new(parsed, sink, dispatcher, ids, credential, stop);
+    let summary = rt.run(shutdown_signal()).await?;
+
+    eprintln!(
+        "✓ subscription stopped — received={} dispatched={} spooled={} replayed={} failed={} pending_spooled={}",
+        summary.received,
+        summary.dispatched,
+        summary.spooled,
+        summary.replayed,
+        summary.failed,
+        summary.pending_spooled,
+    );
+    eprintln!("  event-sourced trail: {}", events_path.display());
+    Ok(())
+}
+
+/// Resolve on Ctrl-C (SIGINT) or SIGTERM (the K8s/Cloud-Run termination shape,
+/// kept consistent so the same drain-on-shutdown contract holds locally).
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+fn slug(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '_' })
+        .collect()
+}

--- a/src/subscribe/runtime.rs
+++ b/src/subscribe/runtime.rs
@@ -1,0 +1,421 @@
+//! The local subscription drain loop (RFC #90 Phase 6, §5.3).
+//!
+//! Holds a `kind: Subscription`'s source open in-process and turns each
+//! received message into one in-process playbook run (or a `POST /api/execute`
+//! when `--dispatch server`), honoring the header-directive allowlist (§7) and
+//! the store-and-forward spool (§8, `local_disk`).  Every step emits the same
+//! [`ExecutorEvent`] envelope the in-cluster runtime emits — to a local
+//! [`FileEventSink`] (JSONL) here — so a local run produces a replayable
+//! event-sourced log identical in shape to the in-cluster / Cloud Run trail.
+//!
+//! Lifecycle events (`subscription.lifecycle` registered/activated/drained/
+//! deactivated) bracket the run; per message the loop emits
+//! `subscription.message.received` → `playbook.started` → `playbook.completed`
+//! /`failed`, plus `subscription.message.directives_applied` when directives
+//! fire and the six spool/circuit events when buffering kicks in.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use noetl_events::{EventSink, ExecutorEvent};
+use noetl_tools::tools::source::{
+    AckMode, DispatchPlan, PollOptions, PolledMessage, SourceClient,
+};
+use noetl_tools::tools::build_source;
+use noetl_tools::ExecutionContext;
+
+use crate::subscribe::dispatch::Dispatcher;
+use crate::subscribe::sink::LocalIdGen;
+use crate::subscribe::spec::ParsedSpec;
+use crate::subscribe::spool::{LocalSpoolRuntime, Routing};
+
+/// Idle backoff when a poll returns nothing.
+const POLL_IDLE_MS: u64 = 300;
+
+/// How the loop terminates.
+#[derive(Debug, Clone, Copy)]
+pub enum StopWhen {
+    /// Run forever (until Ctrl-C / SIGTERM).
+    Never,
+    /// Stop after `n` messages have been *handled* (dispatched + spooled).
+    /// Used by `--max-messages` for bounded local runs / proofs.
+    Handled(u64),
+    /// Drain the source once (one non-empty poll) then exit (`--once`).
+    OneDrain,
+}
+
+/// Runs one local subscription to completion / stop condition.
+pub struct LocalRuntime {
+    spec: ParsedSpec,
+    sink: Arc<dyn EventSink>,
+    dispatcher: Arc<dyn Dispatcher>,
+    ids: Arc<LocalIdGen>,
+    /// Optional local credential JSON injected into the source-build context
+    /// (e.g. a NATS token / Pub/Sub bearer) by alias.  Never a server call.
+    credential: Option<(String, String)>,
+    stop: StopWhen,
+}
+
+/// Summary returned for the final report.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct RunSummary {
+    pub subscription_id: i64,
+    pub received: u64,
+    pub dispatched: u64,
+    pub failed: u64,
+    pub spooled: u64,
+    pub replayed: u64,
+    pub pending_spooled: usize,
+}
+
+impl LocalRuntime {
+    pub fn new(
+        spec: ParsedSpec,
+        sink: Arc<dyn EventSink>,
+        dispatcher: Arc<dyn Dispatcher>,
+        ids: Arc<LocalIdGen>,
+        credential: Option<(String, String)>,
+        stop: StopWhen,
+    ) -> Self {
+        Self {
+            spec,
+            sink,
+            dispatcher,
+            ids,
+            credential,
+            stop,
+        }
+    }
+
+    /// Run the loop until `shutdown` resolves or the stop condition is met.
+    /// Builds the source client from the spec, then drives the drain loop.
+    pub async fn run<F>(&self, shutdown: F) -> Result<RunSummary>
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        // Build the source client (resolve the credential alias into the
+        // build context — local file/env, never a server round-trip).
+        let mut ctx = ExecutionContext::default();
+        if let Some((alias, json)) = &self.credential {
+            ctx.set_secret(alias.clone(), json.clone());
+        }
+        let source = build_source(&self.spec.source_cfg, &ctx)
+            .map_err(|e| anyhow::anyhow!("build source: {e}"))?;
+        self.run_with_source(source, shutdown).await
+    }
+
+    /// Drive the loop against a pre-built source (the test seam + the body of
+    /// [`run`]).  Brackets the loop with the register/activate +
+    /// drain/deactivate lifecycle events and builds the local spool.
+    pub async fn run_with_source<F>(
+        &self,
+        source: Box<dyn SourceClient>,
+        shutdown: F,
+    ) -> Result<RunSummary>
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        let subscription_id = self.ids.next();
+        let mut summary = RunSummary {
+            subscription_id,
+            ..Default::default()
+        };
+        let source_name = source.source_name();
+
+        // Lifecycle: registered → activated (event-sourced, RFC §4.3).
+        self.lifecycle(subscription_id, "registered", "REGISTERED").await;
+        self.lifecycle(subscription_id, "activated", "ACTIVE").await;
+        tracing::info!(
+            subscription_id,
+            path = %self.spec.path,
+            source = source_name,
+            playbook = %self.spec.default_playbook,
+            dispatch = %self.dispatcher.label(),
+            "local subscription activated"
+        );
+
+        // Build the local spool runtime (None when spool.mode: off).
+        let mut spool = LocalSpoolRuntime::build(
+            &self.spec.spool,
+            self.sink.clone(),
+            self.dispatcher.clone(),
+            self.spec.path.clone(),
+            subscription_id,
+            source_name.to_string(),
+            self.spec.default_playbook.clone(),
+            self.spec.default_pool.clone(),
+            self.spec.payload_from.clone(),
+        )
+        .await
+        .context("build local spool runtime")?;
+
+        let opts = PollOptions::new(Some(self.spec.batch), self.spec.timeout_ms, AckMode::OnSuccess);
+
+        let result = self
+            .run_loop(
+                &*source,
+                source_name,
+                subscription_id,
+                &opts,
+                spool.as_mut(),
+                &mut summary,
+                shutdown,
+            )
+            .await;
+
+        if let Some(s) = spool.as_ref() {
+            summary.pending_spooled = s.pending().await;
+        }
+
+        // Lifecycle: drained → deactivated.
+        self.lifecycle(subscription_id, "drained", "DRAINING").await;
+        self.lifecycle(subscription_id, "deactivated", "DEACTIVATED").await;
+        tracing::info!(subscription_id, "local subscription stopped");
+
+        result.map(|_| summary)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_loop<F>(
+        &self,
+        source: &dyn SourceClient,
+        source_name: &str,
+        subscription_id: i64,
+        opts: &PollOptions,
+        mut spool: Option<&mut LocalSpoolRuntime>,
+        summary: &mut RunSummary,
+        shutdown: F,
+    ) -> Result<()>
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        tokio::pin!(shutdown);
+        loop {
+            // Spool maintenance: probe declared downstreams; drain on recovery.
+            if let Some(s) = spool.as_deref_mut() {
+                let recovered = s.maybe_probe().await;
+                if !recovered.is_empty() && s.drain_before_live() {
+                    let before = s.pending().await;
+                    if let Err(e) = s.drain().await {
+                        tracing::warn!(error = %e, "local spool drain failed (will retry)");
+                    } else {
+                        let after = s.pending().await;
+                        summary.replayed += before.saturating_sub(after) as u64;
+                    }
+                }
+            }
+
+            let outcome = tokio::select! {
+                biased;
+                _ = &mut shutdown => { tracing::info!(subscription_id, "shutdown signal received"); break; }
+                r = source.poll(opts) => r,
+            };
+            let outcome = match outcome {
+                Ok(o) => o,
+                Err(e) => {
+                    tracing::warn!(source = source_name, error = %e, "source poll failed");
+                    tokio::time::sleep(Duration::from_millis(POLL_IDLE_MS)).await;
+                    continue;
+                }
+            };
+            let received = outcome.count() as u64;
+            if received == 0 {
+                if matches!(self.stop, StopWhen::OneDrain) && summary.received > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(POLL_IDLE_MS)).await;
+                continue;
+            }
+            summary.received += received;
+
+            for msg in &outcome.messages {
+                let plan = self.spec.directives.resolve(&msg.headers);
+                self.emit_received(subscription_id, msg, source_name).await;
+
+                // Spool/circuit routing first.
+                if let Some(s) = spool.as_deref_mut() {
+                    match s.route_message(msg, &plan).await {
+                        Routing::Spooled => {
+                            summary.spooled += 1;
+                            if self.reached_stop(summary) {
+                                return Ok(());
+                            }
+                            continue;
+                        }
+                        Routing::Dropped => {
+                            summary.failed += 1;
+                            continue;
+                        }
+                        Routing::Dispatch => {}
+                    }
+                }
+
+                let res = self.dispatch_one(subscription_id, msg, &plan).await;
+                if let Some(s) = spool.as_deref_mut() {
+                    s.report_dispatch(&plan, msg, res.as_ref().map(|r| r.ok()).unwrap_or(false))
+                        .await;
+                }
+                match res {
+                    Ok(r) if r.ok() => summary.dispatched += 1,
+                    Ok(r) => {
+                        summary.failed += 1;
+                        tracing::warn!(message_id = %msg.id, error = ?r.error, "message run failed");
+                    }
+                    Err(e) => {
+                        summary.failed += 1;
+                        tracing::warn!(message_id = %msg.id, error = %e, "message dispatch failed");
+                    }
+                }
+                if self.reached_stop(summary) {
+                    return Ok(());
+                }
+            }
+
+            if matches!(self.stop, StopWhen::OneDrain) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn reached_stop(&self, summary: &RunSummary) -> bool {
+        match self.stop {
+            StopWhen::Handled(n) => summary.dispatched + summary.spooled + summary.failed >= n,
+            _ => false,
+        }
+    }
+
+    /// Dispatch one message + emit the `playbook.started`/`completed` pair
+    /// (RFC §3.4) and a `directives_applied` audit when directives fired.
+    async fn dispatch_one(
+        &self,
+        subscription_id: i64,
+        msg: &PolledMessage,
+        plan: &DispatchPlan,
+    ) -> Result<crate::subscribe::dispatch::DispatchResult> {
+        let playbook = plan
+            .playbook_override
+            .clone()
+            .unwrap_or_else(|| self.spec.default_playbook.clone());
+        let pool = plan
+            .execution_pool_override
+            .clone()
+            .or_else(|| self.spec.default_pool.clone());
+
+        let result = self
+            .dispatcher
+            .dispatch(
+                &playbook,
+                pool.as_deref(),
+                msg,
+                plan,
+                &self.spec.payload_from,
+                &self.spec.path,
+                self.source_label(),
+            )
+            .await?;
+
+        let exec = result.execution_id;
+        // playbook.started (child execution).
+        self.emit_child(
+            exec,
+            "playbook.started",
+            "STARTED",
+            serde_json::json!({
+                "subscription": self.spec.path,
+                "parent_execution_id": subscription_id,
+                "message_id": msg.id,
+                "playbook": playbook,
+                "pool": pool,
+            }),
+        )
+        .await;
+        // playbook.completed / failed.
+        let (etype, status) = if result.ok() {
+            ("playbook.completed", "COMPLETED")
+        } else {
+            ("playbook.failed", "FAILED")
+        };
+        self.emit_child(
+            exec,
+            etype,
+            status,
+            serde_json::json!({
+                "subscription": self.spec.path,
+                "message_id": msg.id,
+                "error": result.error,
+            }),
+        )
+        .await;
+
+        // directives_applied audit (RFC §7.6).
+        if !plan.applied.is_empty() || plan.trace.is_some() {
+            self.emit_child(
+                exec,
+                "subscription.message.directives_applied",
+                "APPLIED",
+                serde_json::json!({
+                    "message_id": msg.id,
+                    "applied": plan.applied,
+                    "route_override": { "playbook": plan.playbook_override, "pool": plan.execution_pool_override },
+                    "trace": plan.trace,
+                }),
+            )
+            .await;
+        }
+        Ok(result)
+    }
+
+    fn source_label(&self) -> &str {
+        &self.spec.source_cfg.source
+    }
+
+    async fn emit_received(&self, subscription_id: i64, msg: &PolledMessage, source: &str) {
+        self.emit_child(
+            subscription_id,
+            "subscription.message.received",
+            "RECEIVED",
+            serde_json::json!({
+                "subscription": self.spec.path,
+                "source": source,
+                "message_id": msg.id,
+                "headers": msg.headers,
+            }),
+        )
+        .await;
+    }
+
+    async fn lifecycle(&self, subscription_id: i64, phase: &str, status: &str) {
+        self.emit_child(
+            subscription_id,
+            "subscription.lifecycle",
+            status,
+            serde_json::json!({ "subscription": self.spec.path, "phase": phase }),
+        )
+        .await;
+    }
+
+    async fn emit_child(
+        &self,
+        execution_id: i64,
+        event_type: &str,
+        status: &str,
+        context: serde_json::Value,
+    ) {
+        let event = ExecutorEvent {
+            execution_id,
+            event_type: event_type.to_string(),
+            step: "ingress".to_string(),
+            status: status.to_string(),
+            created_at: chrono::Utc::now(),
+            context,
+            event_id: None,
+            worker_id: Some("cli-local".to_string()),
+            meta: Some(serde_json::json!({ "emitter": "subscribe_runtime" })),
+        };
+        if let Err(e) = self.sink.emit(event).await {
+            tracing::debug!(event_type, error = %e, "local event emit failed (non-fatal)");
+        }
+    }
+}

--- a/src/subscribe/sink.rs
+++ b/src/subscribe/sink.rs
@@ -1,0 +1,242 @@
+//! Local event sinks for `noetl subscribe` (RFC #90 Phase 6, §5.3).
+//!
+//! The in-cluster subscription runtime emits its event-sourced trail through
+//! the worker's `ControlPlaneClient` (`POST /api/events` → `noetl.event`).
+//! Local mode has no server, so it emits the **same** [`ExecutorEvent`]
+//! envelope through a [`FileEventSink`] — one JSON object per line (JSONL) on
+//! local disk — producing a replayable event-sourced log identical in shape to
+//! the in-cluster / Cloud Run trail.  Only the sink differs.
+//!
+//! Two sinks ship here:
+//!
+//! - [`FileEventSink`] — appends one event per line to a JSONL file, flushing
+//!   on every emit so the trail survives a crash mid-run (replayability is the
+//!   whole point).
+//! - [`StdoutEventSink`] — pretty single-line summary to stderr for live
+//!   visibility; used alongside the file sink, never instead of it.
+//!
+//! Both implement the shared [`noetl_events::EventSink`] trait, so the local
+//! runtime threads events through `EventSink` exactly as the worker does.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use noetl_events::{EventSink, ExecutorEvent};
+
+/// NoETL snowflake epoch (`2024-01-01T00:00:00Z` in ms) — the fixed offset the
+/// application-side id generator counts from (`observability.md` Principle 3).
+const NOETL_EPOCH_MS: u64 = 1_704_067_200_000;
+
+/// Application-side id generator for CLI local mode.
+///
+/// Per `observability.md` Principle 3, ids that need to be available *before*
+/// a row would hit a database (here: the subscription's own id + every
+/// per-message child execution id) are generated in the process, not by the
+/// DB.  Local mode has no DB at all, so this is the only generator — a
+/// snowflake-shaped `(timestamp, machine_id, sequence)` layout that stays
+/// unique + sortable within a host.  `machine_id` is a stable hash of
+/// hostname + pid (the value Principle 3 prescribes for CLI local mode).
+#[derive(Debug)]
+pub struct LocalIdGen {
+    machine_id: u64,
+    /// The last id handed out — every `next()` returns strictly more than this
+    /// even if the wall clock stalls or the per-ms sequence (12 bits) would
+    /// wrap, so ids stay unique + sortable regardless of emit rate.
+    last: AtomicU64,
+}
+
+impl LocalIdGen {
+    /// Build a generator seeded from hostname + pid.
+    pub fn new() -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        hostname().hash(&mut h);
+        std::process::id().hash(&mut h);
+        let machine_id = h.finish() & 0x3FF; // 10 bits
+        Self {
+            machine_id,
+            last: AtomicU64::new(0),
+        }
+    }
+
+    /// Next monotonic snowflake id: `(ms << 22) | (machine_id << 12) | seq`,
+    /// forced strictly above the previous id via an atomic CAS so bursts >4096
+    /// ids/ms (which would otherwise wrap the sequence) still increase.
+    pub fn next(&self) -> i64 {
+        let now = now_ms().saturating_sub(NOETL_EPOCH_MS);
+        loop {
+            let prev = self.last.load(Ordering::SeqCst);
+            // The natural snowflake value for "now" with a zero sequence.
+            let base = (now << 22) | (self.machine_id << 12);
+            // Strictly greater than the previous id: advance the time/seq
+            // component when the clock hasn't moved past the last emit.
+            let candidate = base.max(prev + 1);
+            if self
+                .last
+                .compare_exchange(prev, candidate, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return (candidate & 0x7FFF_FFFF_FFFF_FFFF) as i64;
+            }
+        }
+    }
+}
+
+impl Default for LocalIdGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn hostname() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|h| !h.is_empty())
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+/// Wall-clock epoch millis.
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Appends each [`ExecutorEvent`] as one JSON line to a file (JSONL).
+///
+/// The file is the local, replayable event-sourced trail — the same envelope
+/// the in-cluster runtime writes to `noetl.event`, just on disk.  Flushed on
+/// every emit so a crash mid-outage still leaves a complete trail up to the
+/// last event.
+pub struct FileEventSink {
+    file: Mutex<std::fs::File>,
+    /// Mirror a one-line summary to stderr so a live run is visible without
+    /// tailing the file.
+    echo: bool,
+}
+
+impl FileEventSink {
+    /// Open (creating + truncating) the JSONL trail at `path`.
+    pub fn create(path: impl AsRef<Path>, echo: bool) -> Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("create event-sink dir {}", parent.display()))?;
+            }
+        }
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .with_context(|| format!("open event sink {}", path.display()))?;
+        Ok(Self {
+            file: Mutex::new(file),
+            echo,
+        })
+    }
+}
+
+#[async_trait]
+impl EventSink for FileEventSink {
+    async fn emit(&self, event: ExecutorEvent) -> Result<()> {
+        let line = serde_json::to_string(&event).context("serialize event")?;
+        {
+            let mut f = self
+                .file
+                .lock()
+                .map_err(|_| anyhow::anyhow!("event sink mutex poisoned"))?;
+            f.write_all(line.as_bytes())
+                .and_then(|_| f.write_all(b"\n"))
+                .and_then(|_| f.flush())
+                .context("write event line")?;
+        }
+        if self.echo {
+            eprintln!(
+                "  event {:<38} exec={} status={}",
+                event.event_type, event.execution_id, event.status
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Pretty single-line event sink to stderr — visibility without a file.
+/// Available as an alternate sink (RFC §5.3 `stdout` vs `file`); the
+/// `noetl subscribe` command defaults to the [`FileEventSink`] (the replayable
+/// trail) with stderr echo, so this is wired for embedders / future flags.
+#[allow(dead_code)]
+pub struct StdoutEventSink;
+
+#[async_trait]
+impl EventSink for StdoutEventSink {
+    async fn emit(&self, event: ExecutorEvent) -> Result<()> {
+        eprintln!(
+            "event {:<38} exec={} step={} status={} {}",
+            event.event_type,
+            event.execution_id,
+            event.step,
+            event.status,
+            serde_json::to_string(&event.context).unwrap_or_default()
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::sync::Arc;
+
+    fn ev(t: &str, exec: i64) -> ExecutorEvent {
+        ExecutorEvent {
+            execution_id: exec,
+            event_type: t.to_string(),
+            step: "ingress".to_string(),
+            status: "OK".to_string(),
+            created_at: Utc::now(),
+            context: serde_json::json!({ "k": "v" }),
+            event_id: None,
+            worker_id: Some("cli-local".to_string()),
+            meta: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn file_sink_writes_one_json_line_per_event() {
+        let dir = std::env::temp_dir().join(format!("noetl-sink-{}", std::process::id()));
+        let path = dir.join("trail.jsonl");
+        let sink: Arc<dyn EventSink> = Arc::new(FileEventSink::create(&path, false).unwrap());
+        sink.emit(ev("subscription.lifecycle", 1)).await.unwrap();
+        sink.emit(ev("subscription.message.received", 2)).await.unwrap();
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2, "one JSON object per line");
+        // Each line round-trips back into the same envelope (replayable).
+        let first: ExecutorEvent = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first.event_type, "subscription.lifecycle");
+        assert_eq!(first.execution_id, 1);
+        let second: ExecutorEvent = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second.event_type, "subscription.message.received");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn idgen_is_monotonic_and_unique() {
+        let gen = LocalIdGen::new();
+        let mut prev = gen.next();
+        for _ in 0..5_000 {
+            let id = gen.next();
+            assert!(id > prev, "ids strictly increase: {id} <= {prev}");
+            prev = id;
+        }
+    }
+}

--- a/src/subscribe/spec.rs
+++ b/src/subscribe/spec.rs
@@ -1,0 +1,312 @@
+//! Parse a `kind: Subscription` catalog spec for local-mode execution
+//! (RFC #90 Phase 6).
+//!
+//! This is the local-mode sibling of the worker runtime's `parse_spec`
+//! (`repos/worker/src/subscription.rs`).  It extracts the same fields — source
+//! connection, dispatch target, header-directive allowlist, spool block — but
+//! constrains the spool to the **`local_disk`** backend (RFC §8.6: local mode's
+//! only spool backend) and treats `dispatch.playbook` as a file path / catalog
+//! ref the local dispatcher resolves, not a server-side catalog path.
+
+use anyhow::{Context, Result};
+use noetl_tools::spool::{SpoolBackendKind, SpoolSpec};
+use noetl_tools::tools::source::DirectiveSpec;
+use noetl_tools::tools::SubscriptionConfig;
+
+/// Default poll batch for the local drain loop (matches the bounded-drain tool).
+const RUNTIME_BATCH_DEFAULT: u32 = 100;
+
+/// The fields the local runtime needs from a `kind: Subscription` spec.
+#[derive(Debug, Clone)]
+pub struct ParsedSpec {
+    /// Connection config for [`noetl_tools::tools::build_source`].
+    pub source_cfg: SubscriptionConfig,
+    /// Optional credential alias (resolved from a local credential file, never
+    /// a server round-trip in local mode).
+    pub auth_alias: Option<String>,
+    /// Target playbook run per message — a file path or catalog ref the local
+    /// dispatcher resolves.
+    pub default_playbook: String,
+    /// Which part of the normalized message becomes the playbook body.
+    pub payload_from: String,
+    /// Default downstream pool label (matched against declared spool downstreams).
+    pub default_pool: Option<String>,
+    /// Header-directive allowlist (RFC §7).
+    pub directives: DirectiveSpec,
+    /// Store-and-forward spool config (RFC §8) — `local_disk` only in local mode.
+    pub spool: SpoolSpec,
+    /// Subscription path / name (for the event envelope + spool item subject).
+    pub path: String,
+    /// Poll batch size.
+    pub batch: u32,
+    /// Poll wait.
+    pub timeout_ms: Option<u64>,
+}
+
+/// Parse a `kind: Subscription` YAML into the local [`ParsedSpec`].
+///
+/// `path` is the subscription's identity (its file path or catalog name) — it
+/// rides every event + spool item so the local trail is attributable.
+/// `spool_dir_override` (from `--spool-dir`) wins over the spec's
+/// `spool.path`; when neither is set and the spool buffers, a default under
+/// the events directory is used by the caller.
+pub fn parse_spec(
+    yaml: &serde_yaml::Value,
+    path: &str,
+    spool_dir_override: Option<&str>,
+) -> Result<ParsedSpec> {
+    let kind = yaml.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if kind != "Subscription" {
+        anyhow::bail!(
+            "expected 'kind: Subscription', got '{}' — `noetl subscribe` runs a kind:Subscription spec",
+            kind
+        );
+    }
+    let spec = yaml.get("spec").context("subscription YAML missing 'spec'")?;
+
+    let source = spec
+        .get("source")
+        .and_then(|v| v.as_str())
+        .context("subscription spec missing 'source'")?
+        .to_string();
+
+    let auth_alias = spec.get("auth").and_then(|v| v.as_str()).map(str::to_string);
+
+    // Connection config: source + every connection key SubscriptionConfig knows.
+    let mut cfg = serde_json::Map::new();
+    cfg.insert("source".to_string(), serde_json::json!(source));
+    for key in [
+        "url", "user", "password", "token", "stream", "consumer", "subscription", "endpoint",
+        "topic", "group", "brokers",
+    ] {
+        if let Some(v) = spec.get(key) {
+            cfg.insert(key.to_string(), serde_json::to_value(v)?);
+        }
+    }
+    if let Some(alias) = &auth_alias {
+        cfg.insert("auth".to_string(), serde_json::json!(alias));
+    }
+    let source_cfg: SubscriptionConfig = serde_json::from_value(serde_json::Value::Object(cfg))
+        .context("subscription spec did not yield a valid source config")?;
+
+    // runtime knobs.
+    let runtime = spec.get("runtime");
+    let batch = runtime
+        .and_then(|r| r.get("batch"))
+        .and_then(|v| v.as_u64())
+        .map(|b| b as u32)
+        .unwrap_or(RUNTIME_BATCH_DEFAULT);
+    let timeout_ms = runtime
+        .and_then(|r| r.get("timeout_ms"))
+        .and_then(|v| v.as_u64());
+
+    // dispatch block.
+    let dispatch = spec.get("dispatch").context("subscription spec missing 'dispatch'")?;
+    let default_playbook = dispatch
+        .get("playbook")
+        .and_then(|v| v.as_str())
+        .context("subscription spec missing 'dispatch.playbook'")?
+        .to_string();
+    let payload_from = dispatch
+        .get("payload_from")
+        .and_then(|v| v.as_str())
+        .unwrap_or("message.json")
+        .to_string();
+    let default_pool = dispatch
+        .get("execution_pool")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    // headers (directive allowlist) — optional.
+    let directives = match spec.get("headers") {
+        Some(h) => {
+            let json = serde_json::to_value(h)
+                .context("subscription spec 'headers' is not serializable")?;
+            DirectiveSpec::parse(&json)
+                .map_err(|e| anyhow::anyhow!("invalid subscription 'headers' block: {e}"))?
+        }
+        None => DirectiveSpec::default(),
+    };
+
+    // spool block — optional; absent → off.  Local mode only supports the
+    // `local_disk` backend (RFC §8.6); rewrite the backend + path so a spec
+    // authored for the in-cluster `nats_object`/`gcs` backend still runs
+    // locally (the engine + ordering + circuit logic are backend-agnostic).
+    let spool = match spec.get("spool") {
+        Some(s) => {
+            let mut json = serde_json::to_value(s)
+                .context("subscription spec 'spool' is not serializable")?;
+            localize_spool(&mut json, spool_dir_override, path);
+            SpoolSpec::parse(Some(&json))
+                .map_err(|e| anyhow::anyhow!("invalid subscription 'spool' block: {e}"))?
+        }
+        None if spool_dir_override.is_some() => {
+            // `--spool-dir` with no spec block → buffer_and_ack/local_disk default.
+            let json = serde_json::json!({
+                "mode": "buffer_and_ack",
+                "backend": "local_disk",
+                "path": spool_dir_override.unwrap(),
+            });
+            SpoolSpec::parse(Some(&json))
+                .map_err(|e| anyhow::anyhow!("invalid --spool-dir default: {e}"))?
+        }
+        None => SpoolSpec::off(),
+    };
+
+    // Belt-and-suspenders: the localizer should have forced this already.
+    if spool.buffers() && spool.backend != SpoolBackendKind::LocalDisk {
+        anyhow::bail!(
+            "local mode supports only the 'local_disk' spool backend (got '{}'); \
+             omit `backend:` or set it to local_disk",
+            spool.backend.as_str()
+        );
+    }
+
+    Ok(ParsedSpec {
+        source_cfg,
+        auth_alias,
+        default_playbook,
+        payload_from,
+        default_pool,
+        directives,
+        spool,
+        path: path.to_string(),
+        batch,
+        timeout_ms,
+    })
+}
+
+/// Rewrite a spool JSON block for local execution: force `backend: local_disk`
+/// and resolve a concrete `path` (CLI override > spec path > a per-subscription
+/// default under `./.noetl-spool/`).
+fn localize_spool(json: &mut serde_json::Value, dir_override: Option<&str>, path: &str) {
+    let Some(map) = json.as_object_mut() else {
+        return;
+    };
+    map.insert("backend".to_string(), serde_json::json!("local_disk"));
+    let resolved = dir_override
+        .map(str::to_string)
+        .or_else(|| map.get("path").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!(".noetl-spool/{}", slug(path)));
+    map.insert("path".to_string(), serde_json::json!(resolved));
+}
+
+/// Filesystem-safe slug of a subscription path for the default spool dir.
+fn slug(path: &str) -> String {
+    path.chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn parses_nats_source_and_dispatch() {
+        let spec = parse_spec(
+            &yaml(
+                r#"
+kind: Subscription
+spec:
+  source: nats
+  url: nats://localhost:4222
+  stream: ORDERS
+  consumer: orders-local
+  runtime: { batch: 25, timeout_ms: 2000 }
+  dispatch: { playbook: ./playbooks/process.yaml, execution_pool: local }
+"#,
+            ),
+            "subscriptions/orders",
+            None,
+        )
+        .unwrap();
+        assert_eq!(spec.source_cfg.source, "nats");
+        assert_eq!(spec.source_cfg.stream.as_deref(), Some("ORDERS"));
+        assert_eq!(spec.default_playbook, "./playbooks/process.yaml");
+        assert_eq!(spec.default_pool.as_deref(), Some("local"));
+        assert_eq!(spec.batch, 25);
+        assert_eq!(spec.timeout_ms, Some(2000));
+        assert!(!spec.spool.buffers());
+    }
+
+    #[test]
+    fn rejects_non_subscription_kind() {
+        let err = parse_spec(&yaml("kind: Playbook\nspec: {}\n"), "p", None).unwrap_err();
+        assert!(format!("{err}").contains("kind: Subscription"));
+    }
+
+    #[test]
+    fn requires_dispatch_playbook() {
+        let err = parse_spec(
+            &yaml("kind: Subscription\nspec:\n  source: nats\n  stream: S\n  consumer: C\n  dispatch: {}\n"),
+            "p",
+            None,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("dispatch.playbook"));
+    }
+
+    #[test]
+    fn forces_local_disk_backend_even_when_spec_says_nats_object() {
+        // A spec authored for the in-cluster nats_object backend still runs
+        // locally — the localizer rewrites backend + path.
+        let spec = parse_spec(
+            &yaml(
+                r#"
+kind: Subscription
+spec:
+  source: nats
+  stream: IOT
+  consumer: iot-local
+  dispatch: { playbook: ./ingest.yaml, execution_pool: warehouse }
+  spool:
+    mode: buffer_and_ack
+    backend: nats_object
+    bucket: noetl_spool_iot
+    ordering: per_key
+    ordering_key: device_id
+    circuit:
+      trip_after: 2
+      probe_after_ms: 500
+      probe_interval_ms: 300
+      downstream:
+        - { name: warehouse, type: http, target: "http://127.0.0.1:9/health" }
+"#,
+            ),
+            "subscriptions/iot",
+            None,
+        )
+        .unwrap();
+        assert!(spec.spool.buffers());
+        assert_eq!(spec.spool.backend, SpoolBackendKind::LocalDisk);
+        assert!(spec.spool.path.is_some(), "a concrete local path was resolved");
+        assert_eq!(spec.spool.ordering_key.as_deref(), Some("device_id"));
+        assert_eq!(spec.spool.circuit.downstream.len(), 1);
+    }
+
+    #[test]
+    fn spool_dir_override_wins() {
+        let spec = parse_spec(
+            &yaml(
+                r#"
+kind: Subscription
+spec:
+  source: nats
+  stream: S
+  consumer: C
+  dispatch: { playbook: ./p.yaml }
+  spool: { mode: buffer_and_ack, backend: local_disk, path: /tmp/from-spec }
+"#,
+            ),
+            "p",
+            Some("/tmp/from-cli"),
+        )
+        .unwrap();
+        assert_eq!(spec.spool.path.as_deref(), Some("/tmp/from-cli"));
+    }
+}

--- a/src/subscribe/spool.rs
+++ b/src/subscribe/spool.rs
@@ -1,0 +1,488 @@
+//! Store-and-forward spool for `noetl subscribe` local mode (RFC #90 Phase 6,
+//! §8.6 — `local_disk` backend).
+//!
+//! This is the local-mode sibling of the worker runtime's `SpoolRuntime`
+//! (`repos/worker/src/spool_runtime.rs`).  The spool *engine* + *circuit
+//! breaker* + *ordering* + *idempotency* + *dead-letter* + *retention* logic
+//! all live in [`noetl_tools::spool`] (pure, unit-tested upstream); this module
+//! is the local glue:
+//!
+//! - durable backend = [`noetl_tools::spool::LocalDiskBackend`] (the only
+//!   backend local mode supports, §8.6) under the subscription's spool dir;
+//! - circuit state persists to a **JSON file** next to the spool (mirroring the
+//!   in-cluster NATS-KV persistence) so a restart mid-outage rehydrates the
+//!   breaker phase;
+//! - events emit through the [`EventSink`] (the local `FileEventSink`), so the
+//!   six spool/circuit event types land in the same replayable JSONL trail;
+//! - replay dispatches **in-process** through the same [`Dispatcher`] the live
+//!   path uses.
+//!
+//! The loss-safety contract is identical to the worker's: the bounded `poll`
+//! already acked the batch on fetch, so a message in hand is no longer on the
+//! source; `buffer_and_ack` durably writes it to the spool before doing
+//! anything else, and the circuit only drains after the active probe confirms
+//! the downstream is reachable.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use noetl_events::{EventSink, ExecutorEvent};
+use noetl_tools::spool::{
+    probe_downstream, Admission, CircuitDecision, CircuitRegistry, DeadLetter, LocalDiskBackend,
+    SpoolEngine, SpoolItem, SpoolSpec,
+};
+use noetl_tools::tools::source::{DispatchPlan, PolledMessage};
+
+use crate::subscribe::dispatch::Dispatcher;
+use crate::subscribe::sink::now_ms;
+
+/// What the runtime should do with a message after spool routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Routing {
+    /// Circuit closed (or half-open probe) — dispatch normally.
+    Dispatch,
+    /// Circuit open — message was spooled (already durable); skip dispatch.
+    Spooled,
+    /// Retention ceiling hit with `on_full: stop_acking` — not buffered.
+    Dropped,
+}
+
+/// Per-subscription local spool + circuit runtime.
+pub struct LocalSpoolRuntime {
+    engine: SpoolEngine,
+    circuits: CircuitRegistry,
+    circuit_file: PathBuf,
+    sink: Arc<dyn EventSink>,
+    dispatcher: Arc<dyn Dispatcher>,
+    subscription_path: String,
+    subscription_id: i64,
+    source_name: String,
+    default_playbook: String,
+    default_pool: Option<String>,
+    payload_from: String,
+    probe_interval_ms: u64,
+    last_probe_ms: u64,
+    recv_seq: u64,
+}
+
+impl LocalSpoolRuntime {
+    /// Build the local spool runtime, or `None` when the spec declares no
+    /// buffering (`spool.mode: off` / absent).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn build(
+        spec: &SpoolSpec,
+        sink: Arc<dyn EventSink>,
+        dispatcher: Arc<dyn Dispatcher>,
+        subscription_path: String,
+        subscription_id: i64,
+        source_name: String,
+        default_playbook: String,
+        default_pool: Option<String>,
+        payload_from: String,
+    ) -> Result<Option<Self>> {
+        if !spec.buffers() {
+            return Ok(None);
+        }
+        let path = spec
+            .path
+            .clone()
+            .context("local spool requires a path (set via --spool-dir or spool.path)")?;
+        let backend = LocalDiskBackend::open(&path)
+            .await
+            .map_err(|e| anyhow::anyhow!("open local spool {path}: {e}"))?;
+        let dlq = LocalDiskBackend::open(format!("{path}/dlq"))
+            .await
+            .map_err(|e| anyhow::anyhow!("open local spool dlq: {e}"))?;
+
+        let mut circuits = CircuitRegistry::new(&spec.circuit);
+        // Circuit state lives next to the spool, not NATS KV — restart-durable
+        // locally (RFC §8.6: "local file").  It goes in a sibling `control/`
+        // dir, NOT the live spool dir: the LocalDiskBackend counts every
+        // `*.json` file in its dir as a spooled item, so a circuit-state.json
+        // there would inflate the pending count.
+        let control_dir = PathBuf::from(&path).join("control");
+        let _ = std::fs::create_dir_all(&control_dir);
+        let circuit_file = control_dir.join("circuit-state.json");
+        if let Ok(bytes) = std::fs::read(&circuit_file) {
+            if let Ok(snapshot) = serde_json::from_slice(&bytes) {
+                circuits.restore(&snapshot);
+                tracing::info!("restored local circuit state from {}", circuit_file.display());
+            }
+        }
+
+        let probe_interval_ms = spec.circuit.probe_interval_ms;
+        let engine = SpoolEngine::new(spec.clone(), Box::new(backend), Box::new(dlq));
+
+        tracing::info!(
+            subscription_id,
+            mode = spec.mode.as_str(),
+            backend = "local_disk",
+            path = %path,
+            ordering = spec.ordering.as_str(),
+            downstreams = circuits.downstreams().count(),
+            "local spool runtime active"
+        );
+
+        Ok(Some(Self {
+            engine,
+            circuits,
+            circuit_file,
+            sink,
+            dispatcher,
+            subscription_path,
+            subscription_id,
+            source_name,
+            default_playbook,
+            default_pool,
+            payload_from,
+            probe_interval_ms,
+            last_probe_ms: 0,
+            recv_seq: 0,
+        }))
+    }
+
+    fn route(&mut self, plan: &DispatchPlan) -> (String, CircuitDecision) {
+        let resolved = plan
+            .execution_pool_override
+            .as_deref()
+            .or(self.default_pool.as_deref());
+        let downstream = self.circuits.route(resolved).to_string();
+        let now = now_ms();
+        let decision = self.circuits.breaker_mut(&downstream).decide(now);
+        (downstream, decision)
+    }
+
+    /// Route one message: dispatch when closed, spool when open.
+    pub async fn route_message(&mut self, msg: &PolledMessage, plan: &DispatchPlan) -> Routing {
+        let (downstream, decision) = self.route(plan);
+        match decision {
+            CircuitDecision::Dispatch | CircuitDecision::Probe => Routing::Dispatch,
+            CircuitDecision::Spool => self.spool(msg, plan, &downstream, "circuit_open").await,
+        }
+    }
+
+    async fn spool(
+        &mut self,
+        msg: &PolledMessage,
+        plan: &DispatchPlan,
+        downstream: &str,
+        reason: &str,
+    ) -> Routing {
+        let now = now_ms();
+        self.recv_seq += 1;
+        let ordering_key = self.resolve_ordering_key(msg);
+        let item = SpoolItem::new(
+            self.subscription_path.clone(),
+            self.source_name.clone(),
+            msg.clone(),
+            plan.idempotency_key.clone(),
+            self.recv_seq,
+            ordering_key,
+            downstream.to_string(),
+            reason,
+            now,
+        );
+        let incoming = item.to_bytes().len() as u64;
+        match self.engine.admit(now, incoming).await {
+            Ok(Admission::Accept) => {}
+            Ok(Admission::AcceptWithAlert { spool_bytes }) => {
+                self.emit(
+                    "subscription.spool.alert",
+                    "ALERT",
+                    serde_json::json!({ "downstream": downstream, "spool_bytes": spool_bytes }),
+                )
+                .await;
+            }
+            Ok(Admission::AcceptAfterEvict(evicted)) => {
+                for d in evicted {
+                    self.emit_dead_letter(&d).await;
+                }
+            }
+            Ok(Admission::RejectStopAck) => {
+                self.emit(
+                    "subscription.message.dropped",
+                    "DROPPED",
+                    serde_json::json!({ "message_id": msg.id, "downstream": downstream, "reason": "retention_full" }),
+                )
+                .await;
+                return Routing::Dropped;
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "local spool admit failed");
+                return Routing::Dropped;
+            }
+        }
+
+        match self.engine.spool(&item).await {
+            Ok(spooled) => {
+                self.update_gauge().await;
+                self.emit(
+                    "subscription.message.spooled",
+                    "SPOOLED",
+                    serde_json::json!({
+                        "message_id": msg.id,
+                        "recv_seq": spooled.recv_seq,
+                        "spool_ref": spooled.spool_ref,
+                        "sha256": spooled.sha256,
+                        "downstream": downstream,
+                        "reason": reason,
+                    }),
+                )
+                .await;
+                Routing::Spooled
+            }
+            Err(e) => {
+                tracing::error!(message_id = %msg.id, error = %e, "local spool write failed — message NOT durable");
+                Routing::Dropped
+            }
+        }
+    }
+
+    /// Feed a live-dispatch outcome to the breaker (passive signal).
+    pub async fn report_dispatch(&mut self, plan: &DispatchPlan, msg: &PolledMessage, ok: bool) {
+        let resolved = plan
+            .execution_pool_override
+            .as_deref()
+            .or(self.default_pool.as_deref());
+        let downstream = self.circuits.route(resolved).to_string();
+        let now = now_ms();
+        if ok {
+            let dedup = plan.idempotency_key.clone().unwrap_or_else(|| msg.id.clone());
+            self.engine.mark_dispatched(&dedup);
+            if self.circuits.breaker_mut(&downstream).record_success(now) {
+                self.on_circuit_closed(&downstream).await;
+            }
+        } else if self.circuits.breaker_mut(&downstream).record_failure(now) {
+            self.on_circuit_opened(&downstream).await;
+        }
+    }
+
+    /// Run the active downstream probes if the interval elapsed.  Returns the
+    /// downstreams that just recovered (closed) so the caller can drain.
+    pub async fn maybe_probe(&mut self) -> Vec<String> {
+        let now = now_ms();
+        if now.saturating_sub(self.last_probe_ms) < self.probe_interval_ms {
+            return Vec::new();
+        }
+        self.last_probe_ms = now;
+        let specs: Vec<_> = self.circuits.downstreams().cloned().collect();
+        let mut recovered = Vec::new();
+        for ds in specs {
+            let Some(up) = probe_downstream(&ds).await else {
+                continue;
+            };
+            let breaker = self.circuits.breaker_mut(&ds.name);
+            if up {
+                if breaker.record_success(now) {
+                    self.on_circuit_closed(&ds.name).await;
+                    recovered.push(ds.name.clone());
+                }
+            } else if breaker.record_failure(now) {
+                self.on_circuit_opened(&ds.name).await;
+            }
+        }
+        self.persist_circuit();
+        recovered
+    }
+
+    /// Drain the spool: replay each item in order (idempotency + dead-letter
+    /// via the engine), dispatching in-process and emitting
+    /// `subscription.message.replayed` per item.
+    pub async fn drain(&mut self) -> Result<()> {
+        let pending = self.engine.len().await.unwrap_or(0);
+        if pending == 0 {
+            return Ok(());
+        }
+        self.emit(
+            "subscription.spool.draining",
+            "DRAINING",
+            serde_json::json!({ "pending": pending }),
+        )
+        .await;
+
+        let dispatcher = self.dispatcher.clone();
+        let sink = self.sink.clone();
+        let subscription_path = self.subscription_path.clone();
+        let source_name = self.source_name.clone();
+        let default_playbook = self.default_playbook.clone();
+        let default_pool = self.default_pool.clone();
+        let payload_from = self.payload_from.clone();
+
+        let report = self
+            .engine
+            .drain(|item: SpoolItem| {
+                let dispatcher = dispatcher.clone();
+                let sink = sink.clone();
+                let subscription_path = subscription_path.clone();
+                let source_name = source_name.clone();
+                let default_playbook = default_playbook.clone();
+                let default_pool = default_pool.clone();
+                let payload_from = payload_from.clone();
+                async move {
+                    // Re-resolve a minimal plan for the replayed message so
+                    // routing matches the live path (header redirect honored).
+                    let plan = DispatchPlan::default();
+                    let playbook = item
+                        .message
+                        .headers
+                        .get("x-noetl-route")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| default_playbook.clone());
+                    let result = dispatcher
+                        .dispatch(
+                            &playbook,
+                            default_pool.as_deref(),
+                            &item.message,
+                            &plan,
+                            &payload_from,
+                            &subscription_path,
+                            &source_name,
+                        )
+                        .await
+                        .map_err(|e| {
+                            noetl_tools::ToolError::ExecutionFailed(format!("replay dispatch: {e}"))
+                        })?;
+                    if !result.ok() {
+                        return Err(noetl_tools::ToolError::ExecutionFailed(
+                            result.error.unwrap_or_else(|| "replay run failed".into()),
+                        ));
+                    }
+                    // Per-item replayed audit (best-effort).
+                    let _ = sink
+                        .emit(ExecutorEvent {
+                            execution_id: result.execution_id,
+                            event_type: "subscription.message.replayed".to_string(),
+                            step: "ingress".to_string(),
+                            status: "REPLAYED".to_string(),
+                            created_at: chrono::Utc::now(),
+                            context: serde_json::json!({
+                                "message_id": item.message_id,
+                                "recv_seq": item.recv_seq,
+                                "spool_ref": item.spool_ref(),
+                                "execution_id": result.execution_id,
+                            }),
+                            event_id: None,
+                            worker_id: Some("cli-local".to_string()),
+                            meta: Some(serde_json::json!({ "emitter": "spool_drain" })),
+                        })
+                        .await;
+                    Ok(())
+                }
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("drain: {e}"))?;
+
+        for d in &report.dead_lettered {
+            self.emit_dead_letter(d).await;
+        }
+        self.update_gauge().await;
+        tracing::info!(
+            subscription_id = self.subscription_id,
+            replayed = report.replayed,
+            deduped = report.deduped,
+            dead_lettered = report.dead_lettered.len(),
+            remaining = report.remaining,
+            fully_drained = report.fully_drained,
+            "local spool drain pass complete"
+        );
+        Ok(())
+    }
+
+    /// Whether the runtime should drain backlog before resuming live.
+    pub fn drain_before_live(&self) -> bool {
+        self.engine.drain_before_live()
+    }
+
+    /// Pending spooled item count (for the report + tests).
+    pub async fn pending(&self) -> usize {
+        self.engine.len().await.unwrap_or(0)
+    }
+
+    fn resolve_ordering_key(&self, msg: &PolledMessage) -> Option<String> {
+        let key_name = self.engine.spec().ordering_key.as_deref()?;
+        msg.headers
+            .get(key_name)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
+
+    async fn on_circuit_opened(&mut self, downstream: &str) {
+        let state = self
+            .circuits
+            .breaker(downstream)
+            .map(|b| b.state().clone())
+            .unwrap_or_default();
+        tracing::warn!(downstream, trips = state.trips, "circuit opened — buffering to local spool");
+        self.emit(
+            "subscription.circuit.opened",
+            "OPEN",
+            serde_json::json!({
+                "downstream": downstream,
+                "consecutive_failures": state.consecutive_failures,
+                "trips": state.trips,
+            }),
+        )
+        .await;
+        self.persist_circuit();
+    }
+
+    async fn on_circuit_closed(&mut self, downstream: &str) {
+        tracing::info!(downstream, "circuit closed — downstream recovered");
+        self.emit(
+            "subscription.circuit.closed",
+            "CLOSED",
+            serde_json::json!({ "downstream": downstream }),
+        )
+        .await;
+        self.persist_circuit();
+    }
+
+    async fn emit_dead_letter(&self, d: &DeadLetter) {
+        self.emit(
+            "subscription.message.dead_lettered",
+            "DEAD_LETTERED",
+            serde_json::json!({
+                "message_id": d.message_id,
+                "recv_seq": d.recv_seq,
+                "spool_ref": d.spool_ref,
+                "attempts": d.attempts,
+                "reason": d.reason,
+            }),
+        )
+        .await;
+    }
+
+    async fn update_gauge(&self) {
+        if let Ok(bytes) = self.engine.spool_bytes().await {
+            tracing::debug!(spool_bytes = bytes, "local spool bytes");
+        }
+    }
+
+    fn persist_circuit(&self) {
+        let snapshot = self.circuits.snapshot();
+        if let Ok(bytes) = serde_json::to_vec(&snapshot) {
+            if let Err(e) = std::fs::write(&self.circuit_file, bytes) {
+                tracing::debug!(error = %e, "local circuit persist failed (non-fatal)");
+            }
+        }
+    }
+
+    async fn emit(&self, event_type: &str, status: &str, context: serde_json::Value) {
+        let event = ExecutorEvent {
+            execution_id: self.subscription_id,
+            event_type: event_type.to_string(),
+            step: "ingress".to_string(),
+            status: status.to_string(),
+            created_at: chrono::Utc::now(),
+            context,
+            event_id: None,
+            worker_id: Some("cli-local".to_string()),
+            meta: Some(serde_json::json!({ "emitter": "local_spool_runtime" })),
+        };
+        if let Err(e) = self.sink.emit(event).await {
+            tracing::debug!(event_type, error = %e, "local spool event emit failed (non-fatal)");
+        }
+    }
+}

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -1,0 +1,306 @@
+//! Integration tests for `noetl subscribe` local mode (RFC #90 Phase 6).
+//!
+//! These drive the **real** engine surface — the `noetl_tools` spool engine,
+//! circuit breaker, local_disk backend, ordering, idempotency, dead-letter —
+//! through the local runtime, with a fake in-memory source + a recording
+//! dispatcher so the proofs are deterministic and run in CI (no broker / no
+//! cluster).  The live NATS proof is documented separately in the PR.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use noetl_events::{EventSink, ExecutorEvent};
+use noetl_tools::spool::SpoolSpec;
+use noetl_tools::tools::source::{
+    DispatchPlan, PollOptions, PollOutcome, PolledMessage, SourceClient,
+};
+use noetl_tools::ToolError;
+
+use super::dispatch::{DispatchResult, Dispatcher};
+use super::sink::{FileEventSink, LocalIdGen};
+use super::spec::parse_spec;
+use super::spool::{LocalSpoolRuntime, Routing};
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// A source that yields one fixed batch, then is empty forever.
+struct VecSource {
+    batches: Mutex<VecDeque<Vec<PolledMessage>>>,
+}
+
+impl VecSource {
+    fn new(batch: Vec<PolledMessage>) -> Self {
+        let mut q = VecDeque::new();
+        q.push_back(batch);
+        Self {
+            batches: Mutex::new(q),
+        }
+    }
+}
+
+#[async_trait]
+impl SourceClient for VecSource {
+    fn source_name(&self) -> &'static str {
+        "nats"
+    }
+    async fn poll(&self, _opts: &PollOptions) -> Result<PollOutcome, ToolError> {
+        let batch = self.batches.lock().unwrap().pop_front().unwrap_or_default();
+        Ok(PollOutcome {
+            messages: batch,
+            acked: true,
+            ack_ids: Vec::new(),
+        })
+    }
+}
+
+/// A dispatcher that records every dispatch and can be toggled to fail
+/// (simulating a downstream outage on the in-process run).
+#[derive(Clone, Default)]
+struct RecordingDispatcher {
+    dispatched: Arc<Mutex<Vec<String>>>,
+    fail: Arc<Mutex<bool>>,
+    ids: Arc<Mutex<i64>>,
+}
+
+impl RecordingDispatcher {
+    fn set_fail(&self, fail: bool) {
+        *self.fail.lock().unwrap() = fail;
+    }
+    fn dispatched(&self) -> Vec<String> {
+        self.dispatched.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Dispatcher for RecordingDispatcher {
+    async fn dispatch(
+        &self,
+        _playbook: &str,
+        _pool: Option<&str>,
+        msg: &PolledMessage,
+        _plan: &DispatchPlan,
+        _payload_from: &str,
+        _subscription: &str,
+        _source: &str,
+    ) -> anyhow::Result<DispatchResult> {
+        let id = {
+            let mut g = self.ids.lock().unwrap();
+            *g += 1;
+            *g
+        };
+        if *self.fail.lock().unwrap() {
+            return Ok(DispatchResult {
+                execution_id: id,
+                status: "FAILED".into(),
+                error: Some("downstream outage".into()),
+            });
+        }
+        self.dispatched.lock().unwrap().push(msg.id.clone());
+        Ok(DispatchResult {
+            execution_id: id,
+            status: "COMPLETED".into(),
+            error: None,
+        })
+    }
+    fn label(&self) -> String {
+        "recording".into()
+    }
+}
+
+fn msg(id: &str, data: serde_json::Value) -> PolledMessage {
+    PolledMessage {
+        id: id.to_string(),
+        data,
+        headers: serde_json::Map::new(),
+        attributes: serde_json::json!({}),
+        metadata: serde_json::json!({}),
+        ack_id: None,
+    }
+}
+
+fn read_events(path: &std::path::Path) -> Vec<ExecutorEvent> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("event line round-trips"))
+        .collect()
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let d = std::env::temp_dir().join(format!("noetl-sub-{}-{}", name, std::process::id()));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+// ---------------------------------------------------------------------------
+// Full-loop event-sourcing proof (no broker)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn full_loop_emits_event_sourced_trail_to_filesink() {
+    let dir = tmp("loop");
+    let events = dir.join("trail.jsonl");
+    let sink: Arc<dyn EventSink> = Arc::new(FileEventSink::create(&events, false).unwrap());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let ids = Arc::new(LocalIdGen::new());
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        "kind: Subscription\nspec:\n  source: nats\n  url: nats://x\n  stream: S\n  consumer: C\n  dispatch: { playbook: ./p.yaml }\n",
+    )
+    .unwrap();
+    let spec = parse_spec(&yaml, "subs/orders", None).unwrap();
+
+    let rt = super::runtime::LocalRuntime::new(
+        spec,
+        sink,
+        dispatcher.clone(),
+        ids,
+        None,
+        super::runtime::StopWhen::OneDrain,
+    );
+    let source = Box::new(VecSource::new(vec![
+        msg("m1", serde_json::json!({"order_id": 1})),
+        msg("m2", serde_json::json!({"order_id": 2})),
+    ]));
+
+    let summary = rt
+        .run_with_source(source, futures_pending())
+        .await
+        .unwrap();
+    assert_eq!(summary.received, 2);
+    assert_eq!(summary.dispatched, 2);
+    assert_eq!(dispatcher.dispatched(), vec!["m1", "m2"]);
+
+    let evs = read_events(&events);
+    let types: Vec<&str> = evs.iter().map(|e| e.event_type.as_str()).collect();
+    // Lifecycle brackets + per-message ingress + playbook.started/completed.
+    assert!(types.contains(&"subscription.lifecycle"));
+    assert!(types.contains(&"subscription.message.received"));
+    assert!(types.contains(&"playbook.started"));
+    assert!(types.contains(&"playbook.completed"));
+    // Two messages → two playbook.completed.
+    assert_eq!(types.iter().filter(|t| **t == "playbook.completed").count(), 2);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Local outage → local_disk spool → recovery → ordered replay → idempotency
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn outage_buffers_to_local_disk_then_replays_in_order_on_recovery() {
+    let dir = tmp("spool");
+    let events = dir.join("trail.jsonl");
+    let spool_dir = dir.join("spool");
+    let sink: Arc<dyn EventSink> = Arc::new(FileEventSink::create(&events, false).unwrap());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+
+    // A TCP downstream the test controls: bind = up, drop = down. Discover a
+    // free port, then keep it free (down) to start the outage.
+    let probe_port = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+        // listener dropped here → port closed (downstream "down")
+    };
+    let target = format!("127.0.0.1:{probe_port}");
+
+    let spec_yaml = serde_json::json!({
+        "mode": "buffer_and_ack",
+        "backend": "local_disk",
+        "path": spool_dir.to_str().unwrap(),
+        "ordering": "global",
+        "circuit": {
+            "trip_after": 1,
+            "probe_after_ms": 10,
+            "probe_interval_ms": 0,
+            "downstream": [ { "name": "warehouse", "type": "tcp", "target": target } ]
+        },
+        "drain": { "max_replay_attempts": 5, "on_recovery": "ordered_then_live" }
+    });
+    let spool_spec = SpoolSpec::parse(Some(&spec_yaml)).unwrap();
+    assert!(spool_spec.buffers());
+
+    let mut spool = LocalSpoolRuntime::build(
+        &spool_spec,
+        sink.clone(),
+        dispatcher.clone(),
+        "subs/iot".into(),
+        9999,
+        "nats".into(),
+        "./ingest.yaml".into(),
+        Some("warehouse".into()),
+        "message.json".into(),
+    )
+    .await
+    .unwrap()
+    .expect("spool buffers");
+
+    let plan = DispatchPlan::default();
+
+    // --- Outage: the in-process dispatch fails → circuit opens. ---
+    dispatcher.set_fail(true);
+    let m0 = msg("m0", serde_json::json!({"v": 0}));
+    // First message dispatches (circuit still closed), fails → breaker opens.
+    let r0 = spool.route_message(&m0, &plan).await;
+    assert_eq!(r0, Routing::Dispatch);
+    spool.report_dispatch(&plan, &m0, false).await; // trip_after=1 → opens
+
+    // Next 6 messages are buffered durably to local_disk (no dispatch).
+    for i in 1..=6 {
+        let m = msg(&format!("m{i}"), serde_json::json!({ "v": i }));
+        let routing = spool.route_message(&m, &plan).await;
+        assert_eq!(routing, Routing::Spooled, "message {i} spooled while circuit open");
+    }
+    assert_eq!(spool.pending().await, 6, "6 buffered durably");
+    // The spool dir holds the durable items on disk.
+    let on_disk = std::fs::read_dir(&spool_dir).unwrap().count();
+    assert!(on_disk >= 1, "items written to local_disk");
+
+    // --- Recovery: bring the downstream up, probe closes the circuit. ---
+    let _listener = std::net::TcpListener::bind(format!("127.0.0.1:{probe_port}")).unwrap();
+    dispatcher.set_fail(false);
+    let recovered = spool.maybe_probe().await;
+    assert!(recovered.contains(&"warehouse".to_string()), "circuit recovered: {recovered:?}");
+
+    // --- Drain: ordered replay of the 6 buffered messages. ---
+    spool.drain().await.unwrap();
+    assert_eq!(spool.pending().await, 0, "spool fully drained");
+    assert_eq!(
+        dispatcher.dispatched(),
+        vec!["m1", "m2", "m3", "m4", "m5", "m6"],
+        "replayed in receive order (ordering: global)"
+    );
+
+    // --- Idempotency: a second drain replays nothing. ---
+    let before = dispatcher.dispatched().len();
+    spool.drain().await.unwrap();
+    assert_eq!(dispatcher.dispatched().len(), before, "no duplicate replay");
+
+    // The whole outage is reconstructable from the event trail.
+    let evs = read_events(&events);
+    let types: Vec<&str> = evs.iter().map(|e| e.event_type.as_str()).collect();
+    assert!(types.contains(&"subscription.circuit.opened"));
+    assert!(types.contains(&"subscription.message.spooled"));
+    assert!(types.contains(&"subscription.circuit.closed"));
+    assert!(types.contains(&"subscription.spool.draining"));
+    assert!(types.contains(&"subscription.message.replayed"));
+    assert_eq!(
+        types.iter().filter(|t| **t == "subscription.message.spooled").count(),
+        6
+    );
+    assert_eq!(
+        types.iter().filter(|t| **t == "subscription.message.replayed").count(),
+        6
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A future that never resolves — the loop is bounded by the stop condition,
+/// not the shutdown signal, in these tests.
+async fn futures_pending() {
+    std::future::pending::<()>().await
+}


### PR DESCRIPTION
## Summary

Adds **`noetl subscribe <spec.yaml>`** — run a `kind: Subscription` listener
**standalone in local mode**, no k8s and no NATS-dispatch server required for
the listening itself. It reuses the **same** `noetl_tools::tools::source`
clients + header-directive engine + `noetl_tools::spool` engine the in-cluster
worker runtime uses, and emits the **same** `ExecutorEvent` envelope — to a
local `FileEventSink` (JSONL) — so the event model is identical across
CLI-local / in-cluster / Cloud Run. Phase 6 of the subscription/listener RFC
([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90)), the slice
deferred from Phases 1–2.

## Local dispatch model (RFC §5.3)

A received message either:
- runs the target playbook **in-process** via `PlaybookRunner` — the pure-local
  default; or
- POSTs `/api/execute` to a control plane (`--dispatch server --server-url …`).

Either way the local trail captures the ingress + dispatch records identically.

## What landed (`src/subscribe/`)

| file | role |
|---|---|
| `sink.rs` | `FileEventSink` (one event/line JSONL, flushed per emit) impl of `noetl_events::EventSink`; app-side snowflake id gen (observability P3) |
| `dispatch.rs` | `Dispatcher` trait + `LocalDispatcher` (in-process) + `ServerDispatcher` (POST); message→workload envelope (mirrors worker `build_payload`) |
| `spec.rs` | parse a `kind: Subscription` for local mode; forces spool backend → `local_disk` (§8.6) so an in-cluster spec runs locally unchanged |
| `spool.rs` | local spool runtime over `LocalDiskBackend`: circuit breaker + buffer + ordered replay + idempotency + dead-letter; circuit state in a local file; six spool/circuit events to the FileEventSink; in-process replay |
| `runtime.rs` | continuous drain loop: lifecycle + per-message `received`→`playbook.started`→`completed`/`failed` + `directives_applied`; `--once`/`--max-messages`; Ctrl-C/SIGTERM drain |

`cli`-only — the source + spool surface already ships in `noetl-tools` v3.5.0,
so **no tools change / crate cascade**. Bumps the `noetl-tools` lock 3.0.0 →
3.5.0 (the executor's `"3"` constraint).

## Tests

- 12 subscribe unit/integration tests; full bin suite **53 passed**.
- Deterministic local outage → `local_disk` spool → ordered replay →
  idempotency proof exercising the real `noetl_tools::spool` engine (TCP
  downstream probe toggled in-test).

## Live proof (local mode, against in-cluster NATS on kind)

**Drain + in-process dispatch + event-sourced JSONL:** published 5 messages →
`received=5 dispatched=5 failed=0`; 19-event JSONL trail
(lifecycle×4 + received×5 + playbook.started×5 + playbook.completed×5), every
line round-trips as `ExecutorEvent`.

**`local_disk` spool outage → recovery (live):** downstream (tcp probe) down →
`subscription.circuit.opened` → **6 `subscription.message.spooled`** to
local_disk (recv_seq-ordered object keys on disk), **0 dispatched** (no loss);
bring the downstream up → `subscription.circuit.closed` →
`subscription.spool.draining` → **6 `subscription.message.replayed`** in receive
order → spool drained to 0 (`pending_spooled=0`). The whole outage is
reconstructable from the JSONL trail.

## Finding

The NATS source connects via async-nats `ConnectOptions`, which does **not**
honor `user:pass` embedded in the URL — the spec uses explicit `user`/`password`
fields (or `auth: <alias>` + `--credential`). Documented in
`examples/subscribe/`.

Closes noetl/cli#59
Refs noetl/ai-meta#90