### PR TITLE
feat(build): keep DuckDB in cli via duckdb-integration passthrough [BLOCKED on noetl-tools 3.20.0 re-pin]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,26 @@ path = "src/main.rs"
 name = "ntl"
 path = "src/main.rs"
 
+[features]
+# Enabled by default so every cli build path (cargo install, apt, homebrew)
+# keeps the DuckDB capability.
+default = ["duckdb-integration"]
+# DuckDB integration — passthrough to `noetl-tools/duckdb-integration`.  The cli
+# routes `duckdb` / `ducklake` tool steps through `noetl_tools::tools::DuckdbTool`
+# (via noetl-executor's tools_bridge — see playbook_runner.rs).  noetl-tools
+# >= 3.20.0 gates the DuckDB C++ engine (`libduckdb-sys`) behind this non-default
+# feature (noetl/ai-meta#185); enabling it here keeps cli's noetl-tools DuckDB
+# path REAL after cli re-pins to 3.20.0 (otherwise DuckdbTool becomes a stub
+# that errors at dispatch).
+#
+# In `default` (unlike noetl/worker#183, which keeps it out of default for a fast
+# dev build): the cli already compiles DuckDB via its own `duckdb` dependency
+# below, so this passthrough adds ZERO build cost — the same libduckdb-sys node
+# is shared by feature unification.  Keeping it off default would pay the DuckDB
+# compile anyway AND leave the noetl-tools path a stub — worst of both.
+# REQUIRES noetl-tools >= 3.20.0 (the version that introduced the feature).
+duckdb-integration = ["noetl-tools/duckdb-integration"]
+
 [dependencies]
 # Workspace member crate shipping the shared execution core.  R-1.1
 # PR-2a moves the YAML playbook types out of playbook_runner.rs into


### PR DESCRIPTION
**DRAFT / BLOCKED — do not merge yet.** The `noetl-tools/duckdb-integration` feature reference won't resolve until cli re-pins to noetl-tools 3.20.0 (`cargo update -p noetl-tools`); the lockfile is currently on 3.5.0. **Batch this with the worker re-pin (noetl/worker#183)** so the whole DuckDB-opt-in rollout lands in one coordinated pass.

## What / why (Option A — cli KEEPS DuckDB)

noetl-tools >= 3.20.0 gates the DuckDB C++ engine (`libduckdb-sys`) behind a non-default `duckdb-integration` feature (noetl/ai-meta#185). The cli routes `duckdb`/`ducklake` tool steps through `noetl_tools::tools::DuckdbTool` (via noetl-executor's `tools_bridge` — see `playbook_runner.rs`), reaching noetl-tools via **both** its direct dep and the `executor` (noetl-executor) workspace member. After a re-pin to 3.20.0 that path would become a stub unless the feature is enabled.

## Changes
- `Cargo.toml`: new `[features]` with `default = ["duckdb-integration"]` and `duckdb-integration = ["noetl-tools/duckdb-integration"]`.
- In `default` (unlike noetl/worker#183, which keeps it off default for a fast dev build): cli **already** compiles DuckDB via its own `duckdb` dependency, so this passthrough adds **zero** build cost (same `libduckdb-sys` node by feature unification), and every cli release path (cargo install / apt / homebrew) keeps the capability. Keeping it off default would pay the DuckDB compile anyway AND leave the noetl-tools path a stub — worst of both.

## Verified (cargo tree against real published noetl-tools 3.20.0; throwaway `--precise`, reverted; no build)
- default: `libduckdb-sys → duckdb → {cli own dep, noetl-tools 3.20.0 → (cli direct, noetl-executor)}` — one unified node; noetl-tools path real.
- `--no-default-features`: `libduckdb-sys → duckdb → cli own dep only` — noetl-tools drops out, confirming the passthrough is what keeps its DuckDB path real.

## To land (batch with worker#183 — triggers the coordinated rebuild)
1. noetl-tools 3.20.0 is published ✅ (from noetl/tools#85).
2. `cargo update -p noetl-tools` (re-pin lockfile 3.5.0 → 3.20.0), commit.
3. Build/validate the cli (it compiles DuckDB as before — functionally unchanged).
4. Mark ready + merge.

Refs noetl/ai-meta#185