### PR TITLE
feat(provider): dispatch kind: provider through the local CLI runtime (+ noetl-tools 3.21.0 re-pin, duckdb passthrough)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,9 +2976,9 @@ checksum = "fcdc9657471e917de19608a327a65eafb0d4bef5df5271c991c85982a5ccdf07"
 
 [[package]]
 name = "noetl-tools"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bf1f0da7c2a8d650b90778e05a6731a20730e4862be1e028c3253749f411d4"
+checksum = "3159e17b81756c7a6f81494e01d213f3ed9a62f94a719615926073867c1577a2"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",
@@ -3504,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -1358,6 +1359,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1935,6 +1937,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
@@ -2129,7 +2140,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2310,15 +2321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2380,21 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -2908,6 +2925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "noetl-directives"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc7148910450b0bcf3151481828f43d23ed7b20b75d5171761b6edf2748a2ca"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "noetl-events"
 version = "0.1.0"
 dependencies = [
@@ -2941,10 +2969,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "noetl-tools"
-version = "3.5.0"
+name = "noetl-locator"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c16265c993f0c46c21cc70cc9fa8b4cf71e032429a4a6c1f67d3f35a01c2b69"
+checksum = "fcdc9657471e917de19608a327a65eafb0d4bef5df5271c991c85982a5ccdf07"
+
+[[package]]
+name = "noetl-tools"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bf1f0da7c2a8d650b90778e05a6731a20730e4862be1e028c3253749f411d4"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",
@@ -2959,11 +2993,16 @@ dependencies = [
  "duckdb",
  "futures",
  "gcp_auth",
+ "hmac 0.12.1",
+ "jsonwebtoken",
  "k8s-openapi",
  "kafka",
  "kube",
  "minijinja",
  "noetl-arrow-flight-client 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "noetl-directives",
+ "noetl-locator",
+ "pem",
  "regex",
  "reqwest",
  "rhai",
@@ -2972,6 +3011,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -3382,7 +3422,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
  "rand 0.10.2",
@@ -3402,6 +3442,7 @@ dependencies = [
  "postgres-protocol",
  "serde_core",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3463,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4399,6 +4440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,11 +4769,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4730,15 +4784,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5459,7 +5513,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5487,7 +5541,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -5497,23 +5551,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -5528,32 +5569,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5573,24 +5592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,26 @@ path = "src/main.rs"
 name = "ntl"
 path = "src/main.rs"
 
+[features]
+# Enabled by default so every cli build path (cargo install, apt, homebrew)
+# keeps the DuckDB capability.
+default = ["duckdb-integration"]
+# DuckDB integration — passthrough to `noetl-tools/duckdb-integration`.  The cli
+# routes `duckdb` / `ducklake` tool steps through `noetl_tools::tools::DuckdbTool`
+# (via noetl-executor's tools_bridge — see playbook_runner.rs).  noetl-tools
+# >= 3.20.0 gates the DuckDB C++ engine (`libduckdb-sys`) behind this non-default
+# feature (noetl/ai-meta#185); enabling it here keeps cli's noetl-tools DuckDB
+# path REAL after cli re-pins to 3.20.0 (otherwise DuckdbTool becomes a stub
+# that errors at dispatch).
+#
+# In `default` (unlike noetl/worker#183, which keeps it out of default for a fast
+# dev build): the cli already compiles DuckDB via its own `duckdb` dependency
+# below, so this passthrough adds ZERO build cost — the same libduckdb-sys node
+# is shared by feature unification.  Keeping it off default would pay the DuckDB
+# compile anyway AND leave the noetl-tools path a stub — worst of both.
+# REQUIRES noetl-tools >= 3.20.0 (the version that introduced the feature).
+duckdb-integration = ["noetl-tools/duckdb-integration"]
+
 [dependencies]
 # Workspace member crate shipping the shared execution core.  R-1.1
 # PR-2a moves the YAML playbook types out of playbook_runner.rs into

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -78,5 +78,18 @@ object_store = { version = "0.11", features = ["gcp"] }
 # on the transitive dep from object_store.
 bytes = "1"
 
+[features]
+# DuckDB integration — passthrough to `noetl-tools/duckdb-integration`.
+# noetl-tools >= 3.20.0 gates the DuckDB C++ engine (libduckdb-sys) behind a
+# non-default feature (noetl/ai-meta#185) so builds that never run duckdb steps
+# skip the multi-hour C++ compile.  noetl-executor routes `duckdb` steps through
+# `noetl_tools::tools::DuckdbTool` in `tools_bridge`, so its DuckDB path is a
+# stub unless that feature is enabled.  Off by default here (matching
+# noetl-worker's fast-build default); the cli enables it via its own default
+# passthrough, and feature unification turns it on for the whole cli build
+# graph.  The bridge's real-duckdb dispatch test is gated on this feature.
+default = []
+duckdb-integration = ["noetl-tools/duckdb-integration"]
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/executor/src/playbook.rs
+++ b/executor/src/playbook.rs
@@ -385,6 +385,31 @@ pub enum Tool {
         #[serde(default)]
         args: HashMap<String, String>,
     },
+    /// Cloud provider operation (`kind: provider`) — dispatched through the
+    /// noetl-tools `ProviderTool`.  The CLI captures the provider block's
+    /// fields loosely (`serde_yaml::Value` for the nested / polymorphic ones)
+    /// and hands the assembled, template-rendered config to the tool, which
+    /// owns the action grammar, plan/apply, and LRO polling.  Local mode runs
+    /// the same tool the distributed worker does — see `tools_bridge`.
+    Provider {
+        provider: String,
+        #[serde(default)]
+        runtime: Option<String>,
+        action: String,
+        #[serde(default)]
+        service: Option<String>,
+        /// `bool` or a template string (`"{{ ... }}"`) — resolved by the tool.
+        #[serde(default)]
+        dry_run: Option<serde_yaml::Value>,
+        #[serde(default)]
+        input: Option<serde_yaml::Value>,
+        #[serde(default)]
+        poll: Option<serde_yaml::Value>,
+        /// Provider auth block (apply mode only).  Captured raw and mapped to
+        /// the noetl-tools `AuthConfig` at dispatch; dry-run ignores it.
+        #[serde(default)]
+        auth: Option<serde_yaml::Value>,
+    },
     #[serde(other)]
     Unsupported,
 }

--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -61,9 +61,9 @@ use object_store::ObjectStore;
 use object_store::PutPayload;
 use noetl_tools::auth::GcpAuth;
 use noetl_tools::context::ExecutionContext as ToolsExecutionContext;
-use noetl_tools::registry::{Tool as ToolsRegistryTool, ToolConfig};
+use noetl_tools::registry::{AuthConfig as ToolsAuthConfig, Tool as ToolsRegistryTool, ToolConfig};
 use noetl_tools::result::{ToolResult, ToolStatus};
-use noetl_tools::tools::{DuckdbTool, HttpTool, RhaiTool, ShellTool};
+use noetl_tools::tools::{DuckdbTool, HttpTool, ProviderTool, RhaiTool, ShellTool};
 use tracing::{info_span, Instrument};
 
 use crate::playbook::{AuthConfig as CliAuthConfig, CmdsList, SinkFormat, Tool};
@@ -342,6 +342,41 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
                 "format": format!("{:?}", format).to_lowercase(),
             }),
         ),
+        Tool::Provider {
+            provider,
+            runtime,
+            action,
+            service,
+            dry_run,
+            input,
+            poll,
+            // `auth` is mapped to ToolConfig.auth in the dispatch arm, not into
+            // the config body (the ProviderSpec ignores an `auth` config key).
+            auth: _,
+        } => {
+            // Assemble the provider config body the noetl-tools ProviderSpec
+            // deserializes.  Optional fields are omitted when absent so the
+            // tool's own serde defaults (e.g. runtime=rest, dry_run=true) apply.
+            let mut cfg = serde_json::Map::new();
+            cfg.insert("provider".into(), serde_json::json!(provider));
+            cfg.insert("action".into(), serde_json::json!(action));
+            if let Some(r) = runtime {
+                cfg.insert("runtime".into(), serde_json::json!(r));
+            }
+            if let Some(s) = service {
+                cfg.insert("service".into(), serde_json::json!(s));
+            }
+            if let Some(d) = dry_run {
+                cfg.insert("dry_run".into(), yaml_to_json(d));
+            }
+            if let Some(i) = input {
+                cfg.insert("input".into(), yaml_to_json(i));
+            }
+            if let Some(p) = poll {
+                cfg.insert("poll".into(), yaml_to_json(p));
+            }
+            ("provider", serde_json::Value::Object(cfg))
+        }
         Tool::Unsupported => ("unsupported", serde_json::json!({})),
     };
 
@@ -1193,10 +1228,57 @@ pub async fn dispatch_via_registry(
                  is tracked as a separate follow-up."
             );
         }
+        Tool::Provider { auth, .. } => {
+            // Dispatch through noetl-tools' ProviderTool — the SAME tool the
+            // distributed worker runs.  Local mode therefore executes the cloud
+            // provider action grammar, plan/apply, and LRO polling identically;
+            // there is no CLI-side reimplementation.
+            //
+            // Dry-run (the default, and the credential-free plan path) needs no
+            // auth.  For an apply-mode call the provider's `auth:` block is
+            // mapped into the noetl-tools AuthConfig here; the ProviderTool
+            // refuses an apply with no auth (no ambient ADC fallback).
+            let mut config = to_tools_config(tool);
+            config.auth = match auth {
+                Some(a) => Some(provider_auth_to_tools(a)?),
+                None => None,
+            };
+            let ctx = to_tools_context(bridge);
+            let provider_tool = ProviderTool::new();
+            let result = provider_tool
+                .execute(&config, &ctx)
+                .await
+                .map_err(|e| anyhow::anyhow!("provider dispatch failed: {}", e))?;
+            from_tools_result(result)
+        }
         Tool::Unsupported => {
             anyhow::bail!("unsupported tool kind");
         }
     }
+}
+
+/// Convert a `serde_yaml::Value` to a `serde_json::Value` for the noetl-tools
+/// config body.  Provider config sub-blocks (`input`, `poll`, `dry_run`) arrive
+/// as YAML values from the CLI playbook parse; the tool consumes JSON.
+fn yaml_to_json(v: &serde_yaml::Value) -> serde_json::Value {
+    serde_json::to_value(v).unwrap_or(serde_json::Value::Null)
+}
+
+/// Map a provider `auth:` block (raw YAML) into the noetl-tools `AuthConfig`.
+///
+/// The provider auth shape (`type: gcp_adc`, `credential:`, `scopes:`) maps
+/// directly onto the noetl-tools `AuthConfig` serde surface, so this is a
+/// convert-through-JSON.  A malformed block is reported rather than silently
+/// dropped — an apply-mode step with a broken `auth:` should fail loudly.
+fn provider_auth_to_tools(auth: &serde_yaml::Value) -> Result<ToolsAuthConfig> {
+    let json = yaml_to_json(auth);
+    serde_json::from_value::<ToolsAuthConfig>(json).map_err(|e| {
+        anyhow::anyhow!(
+            "invalid provider `auth:` block (expected e.g. `type: gcp_adc`, \
+             `credential: <alias>`, `scopes: [...]`): {}",
+            e
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1248,6 +1330,124 @@ mod tests {
         assert_eq!(cfg.config["shell"], "bash");
         assert_eq!(cfg.config["capture"], true);
         assert!(cfg.timeout.is_none());
+    }
+
+    #[test]
+    fn to_tools_config_provider_assembles_config_body() {
+        let tool = Tool::Provider {
+            provider: "google".into(),
+            runtime: Some("rest".into()),
+            action: "google.cloudresourcemanager.folders.list".into(),
+            service: None,
+            dry_run: Some(serde_yaml::Value::Bool(true)),
+            input: Some(serde_yaml::to_value(serde_json::json!({
+                "parent": "organizations/1"
+            }))
+            .unwrap()),
+            poll: Some(serde_yaml::to_value(serde_json::json!({
+                "max_attempts": 5
+            }))
+            .unwrap()),
+            auth: None,
+        };
+        let cfg = to_tools_config(&tool);
+        assert_eq!(cfg.kind, "provider");
+        assert_eq!(cfg.config["provider"], "google");
+        assert_eq!(
+            cfg.config["action"],
+            "google.cloudresourcemanager.folders.list"
+        );
+        assert_eq!(cfg.config["runtime"], "rest");
+        assert_eq!(cfg.config["dry_run"], true);
+        assert_eq!(cfg.config["input"]["parent"], "organizations/1");
+        assert_eq!(cfg.config["poll"]["max_attempts"], 5);
+        // Absent optionals are omitted so the tool's serde defaults apply.
+        assert!(cfg.config.get("service").is_none());
+        // Auth is threaded through ToolConfig.auth by the dispatch arm, never
+        // into the config body.
+        assert!(cfg.config.get("auth").is_none());
+    }
+
+    #[test]
+    fn provider_auth_to_tools_maps_gcp_adc_block() {
+        let auth = serde_yaml::to_value(serde_json::json!({
+            "type": "gcp_adc",
+            "credential": "gcp_org_admin",
+            "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
+        }))
+        .unwrap();
+        let mapped = provider_auth_to_tools(&auth).unwrap();
+        assert_eq!(mapped.credential.as_deref(), Some("gcp_org_admin"));
+        assert_eq!(
+            mapped.scopes.as_deref(),
+            Some(&["https://www.googleapis.com/auth/cloud-platform".to_string()][..])
+        );
+
+        // A malformed block is reported, not silently dropped.
+        let bad = serde_yaml::to_value(serde_json::json!({ "type": "not_a_real_type" })).unwrap();
+        assert!(provider_auth_to_tools(&bad).is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_provider_dry_run_returns_would_call_no_auth() {
+        // Dry-run provider dispatch through the bridge: no auth needed, no
+        // network, returns the plan the tool would send.
+        let tool = Tool::Provider {
+            provider: "google".into(),
+            runtime: None,
+            action: "google.cloudresourcemanager.folders.list".into(),
+            service: None,
+            dry_run: Some(serde_yaml::Value::Bool(true)),
+            input: Some(
+                serde_yaml::to_value(serde_json::json!({ "parent": "organizations/42" })).unwrap(),
+            ),
+            poll: None,
+            auth: None,
+        };
+        let vars = empty_vars();
+        let outcome = dispatch_via_registry(&tool, &bridge_ctx(&vars))
+            .await
+            .unwrap();
+        let result = outcome.result.expect("provider dry-run returns a result");
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["dry_run"], serde_json::json!(true));
+        assert_eq!(json["would_call"]["method"], serde_json::json!("GET"));
+        assert_eq!(
+            json["would_call"]["url"],
+            serde_json::json!(
+                "https://cloudresourcemanager.googleapis.com/v3/folders?parent=organizations/42"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_provider_apply_without_auth_errors_no_network() {
+        // Apply mode (dry_run=false) with no auth block → the tool refuses with
+        // a Configuration error and makes no network call.  The bridge surfaces
+        // it as a dispatch error rather than a silent empty outcome.
+        let tool = Tool::Provider {
+            provider: "google".into(),
+            runtime: None,
+            action: "google.serviceusage.services.enable".into(),
+            service: None,
+            dry_run: Some(serde_yaml::Value::Bool(false)),
+            input: Some(
+                serde_yaml::to_value(serde_json::json!({
+                    "project_id": "p", "service_name": "youtube.googleapis.com"
+                }))
+                .unwrap(),
+            ),
+            poll: None,
+            auth: None,
+        };
+        let vars = empty_vars();
+        let err = dispatch_via_registry(&tool, &bridge_ctx(&vars))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("apply mode") || err.to_string().contains("auth"),
+            "error names the missing auth: {err}"
+        );
     }
 
     #[test]
@@ -1509,6 +1709,11 @@ mod tests {
         assert_eq!(outcome.result.as_deref(), Some(r#"{"status": "ok"}"#));
     }
 
+    // Requires the real DuckDB engine — noetl-tools >= 3.20.0 gates it behind
+    // `duckdb-integration`, so without the feature this dispatch hits the stub.
+    // The cli enables the feature by default; run
+    // `cargo test -p noetl-executor --features duckdb-integration` for this test.
+    #[cfg(feature = "duckdb-integration")]
     #[tokio::test]
     async fn dispatch_duckdb_select_returns_rows_array() {
         let vars = empty_vars();

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -1174,12 +1174,116 @@ impl PlaybookRunner {
                 })?;
                 Ok(outcome.result)
             }
+            Tool::Provider {
+                provider,
+                runtime,
+                action,
+                service,
+                dry_run,
+                input,
+                poll,
+                auth,
+            } => {
+                // Render every template in the provider block with the CLI's
+                // renderer first (same contract as the http / rhai arms — the
+                // bridge dispatches against already-rendered input), then hand
+                // the rendered Tool::Provider to the noetl-tools ProviderTool
+                // via the bridge.  The tool owns plan/apply + LRO polling; the
+                // CLI local runtime runs the identical tool the worker does.
+                let rendered_dry_run = match dry_run {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
+                let rendered_input = match input {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
+                let rendered_poll = match poll {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
+                let rendered_auth = match auth {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
+                let rendered_service = match service {
+                    Some(s) => Some(self.render_template(s, context)?),
+                    None => None,
+                };
+
+                if self.verbose {
+                    eprintln!("   ☁️  Executing provider action: {}", action);
+                }
+
+                let rendered_tool = Tool::Provider {
+                    provider: self.render_template(provider, context)?,
+                    runtime: match runtime {
+                        Some(r) => Some(self.render_template(r, context)?),
+                        None => None,
+                    },
+                    action: self.render_template(action, context)?,
+                    service: rendered_service,
+                    dry_run: rendered_dry_run,
+                    input: rendered_input,
+                    poll: rendered_poll,
+                    auth: rendered_auth,
+                };
+                let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {
+                    execution_id: 0, // CLI local mode doesn't carry a snowflake id
+                    step: "<cli-local>",
+                    variables: &context.variables,
+                    server_url: String::new(),
+                    worker_id: None,
+                    command_id: None,
+                };
+                let outcome = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        noetl_executor::tools_bridge::dispatch_via_registry(
+                            &rendered_tool,
+                            &bridge_ctx,
+                        ),
+                    )
+                })?;
+                Ok(outcome.result)
+            }
             Tool::Unsupported => {
                 eprintln!("   Tool not supported in local execution mode");
-                eprintln!("   Supported tools: shell, http, playbook, duckdb, auth, sink");
+                eprintln!("   Supported tools: shell, http, playbook, duckdb, auth, sink, provider");
                 eprintln!("   For other tools (postgres, python, iterator, etc.), use distributed execution");
                 Ok(None)
             }
+        }
+    }
+
+    /// Recursively render every string leaf in a `serde_yaml::Value` with the
+    /// CLI template renderer.  Used to render provider tool config sub-blocks
+    /// (`input`, `poll`, `dry_run`, `auth`) before bridge dispatch.  Mapping
+    /// keys are left verbatim; only values are rendered.
+    fn render_yaml_value(
+        &self,
+        value: &serde_yaml::Value,
+        context: &ExecutionContext,
+    ) -> Result<serde_yaml::Value> {
+        match value {
+            serde_yaml::Value::String(s) => {
+                Ok(serde_yaml::Value::String(self.render_template(s, context)?))
+            }
+            serde_yaml::Value::Sequence(seq) => {
+                let mut out = Vec::with_capacity(seq.len());
+                for item in seq {
+                    out.push(self.render_yaml_value(item, context)?);
+                }
+                Ok(serde_yaml::Value::Sequence(out))
+            }
+            serde_yaml::Value::Mapping(map) => {
+                let mut out = serde_yaml::Mapping::new();
+                for (k, v) in map {
+                    out.insert(k.clone(), self.render_yaml_value(v, context)?);
+                }
+                Ok(serde_yaml::Value::Mapping(out))
+            }
+            // Scalars (bool / number / null / tagged) carry no template.
+            other => Ok(other.clone()),
         }
     }
 


### PR DESCRIPTION
Round 2 of the cloud provider tool (noetl/ai-meta#189), CLI side. Wires the
`kind: provider` tool into `noetl exec --runtime local` so infrastructure
playbooks can plan/apply cloud operations locally — the "replace Terraform,
especially in local mode" goal — running the **same** noetl-tools `ProviderTool`
the distributed worker runs (no CLI-side reimplementation).

Tracks noetl/ai-meta#189.

## What

- `executor/playbook.rs`: new `Tool::Provider` variant capturing the provider
  block (nested/polymorphic fields as `serde_yaml::Value`).
- `executor/tools_bridge.rs`: `to_tools_config` assembles the provider config
  body; a dispatch arm builds the noetl-tools `ProviderTool`, maps the `auth:`
  block into the noetl-tools `AuthConfig` (apply mode; dry-run is
  credential-free), and executes. Adds `yaml_to_json` + `provider_auth_to_tools`.
- `playbook_runner.rs`: `Tool::Provider` arm renders every template in the block
  with the CLI renderer first (same contract as the http/rhai arms), then
  dispatches via the bridge. New `render_yaml_value` recurses string leaves.

## Re-pin + DuckDB (supersedes/unblocks #63)

Re-pins **noetl-tools 3.5.0 → 3.21.0** (the version carrying the provider tool).
`libduckdb-sys` is unchanged (1.2.2), so this adds **no fresh C++ compile** — the
cli already builds DuckDB via its own dep. This branch is based on #63's
`duckdb-integration` passthrough (kept default-on so the re-pin doesn't stub the
cli's DuckDB path), so it **carries and unblocks #63** — the re-pin is exactly
what #63 was waiting on. Recommend closing #63 as superseded once this lands.

Also gives `noetl-executor` a matching `duckdb-integration` passthrough feature
(default off, matching the worker's fast-build default) and gates its
real-DuckDB dispatch test on it, so `cargo test -p noetl-executor` is green
without paying the DuckDB compile and green with `--features duckdb-integration`.

## Verified end-to-end (local runtime)

A dry-run provider playbook run through `noetl exec --runtime local` produces
the real `would_call` plans with CLI-rendered templates:

```
list_folders → GET  https://cloudresourcemanager.googleapis.com/v3/folders?parent=organizations/561323743912
enable_api   → POST https://serviceusage.googleapis.com/v1/projects/shastaratech-youtube-prod/services/youtube.googleapis.com:enable
```

Both dry-run (`dry_run: {{ workload.action != 'apply' }}` → true), credential-free.

Tests: `to_tools_config` assembly, auth mapping (+ malformed reject), bridge
dry-run `would_call`, apply-without-auth refusal. Executor lib suite: 105 passed.

Refs noetl/ai-meta#189, noetl/ai-meta#185