### PR TITLE
feat(provider): local-mode passthrough for endpoint / stack / confirm (round 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,9 +2985,9 @@ checksum = "fcdc9657471e917de19608a327a65eafb0d4bef5df5271c991c85982a5ccdf07"
 
 [[package]]
 name = "noetl-tools"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3159e17b81756c7a6f81494e01d213f3ed9a62f94a719615926073867c1577a2"
+checksum = "ec268353dcf60add6a3b38c0832d182f0e6c7535fac5395c79cb71ddb9821fdf"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,14 @@ noetl-executor = { path = "executor", version = "0.5" }
 # reuses the same source clients (`build_source`), header-directive engine,
 # and store-and-forward spool engine the in-cluster worker runtime uses, so
 # the event model is identical across CLI-local / in-cluster / Cloud Run.
-# `noetl-tools` "3" resolves to the published crate (v3.5.0+) that carries
-# the Phase 1–5 `tools::source` + `spool` surface; default features pull in
-# the pubsub + kafka + gcs source/backends.  `noetl-events` is the shared
+# `noetl-tools` "3.23" pins the round-3 provider surface (confirm-gated
+# destroy + endpoint override + ownership fact/`provider_state` fold) so
+# `noetl exec --runtime local` runs the same round-3 tool the worker does —
+# not just the field passthrough against 3.22.0.  Default features pull in the
+# pubsub + kafka + gcs source/backends.  `noetl-events` is the shared
 # `EventSink` trait + `ExecutorEvent` envelope the local `FileEventSink`
 # implements (same wire shape as the worker's NATS/HTTP sinks).
-noetl-tools = "3"
+noetl-tools = "3.23"
 noetl-events = { path = "events", version = "0.1.0" }
 async-trait = "0.1"
 

--- a/executor/src/playbook.rs
+++ b/executor/src/playbook.rs
@@ -405,6 +405,19 @@ pub enum Tool {
         input: Option<serde_yaml::Value>,
         #[serde(default)]
         poll: Option<serde_yaml::Value>,
+        /// Config-level API endpoint override (Round 3) — testing / emulators
+        /// only.  A base URL string or `{crm,billing,serviceusage}` object; lets
+        /// a playbook be validated offline against wiremock / an emulator.
+        #[serde(default)]
+        endpoint: Option<serde_yaml::Value>,
+        /// Ownership / stack label (Round 3, Fork 1) — scopes the resource
+        /// ownership + drift + orphan projection.
+        #[serde(default)]
+        stack: Option<String>,
+        /// Destroy confirmation digest (Round 3, Fork 2) — required to apply a
+        /// destroy verb; must equal the `plan_digest` from a reviewed dry-run.
+        #[serde(default)]
+        confirm: Option<String>,
         /// Provider auth block (apply mode only).  Captured raw and mapped to
         /// the noetl-tools `AuthConfig` at dispatch; dry-run ignores it.
         #[serde(default)]

--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -350,6 +350,9 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             dry_run,
             input,
             poll,
+            endpoint,
+            stack,
+            confirm,
             // `auth` is mapped to ToolConfig.auth in the dispatch arm, not into
             // the config body (the ProviderSpec ignores an `auth` config key).
             auth: _,
@@ -374,6 +377,15 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             }
             if let Some(p) = poll {
                 cfg.insert("poll".into(), yaml_to_json(p));
+            }
+            if let Some(e) = endpoint {
+                cfg.insert("endpoint".into(), yaml_to_json(e));
+            }
+            if let Some(s) = stack {
+                cfg.insert("stack".into(), serde_json::json!(s));
+            }
+            if let Some(c) = confirm {
+                cfg.insert("confirm".into(), serde_json::json!(c));
             }
             ("provider", serde_json::Value::Object(cfg))
         }
@@ -1348,6 +1360,9 @@ mod tests {
                 "max_attempts": 5
             }))
             .unwrap()),
+            endpoint: None,
+            stack: None,
+            confirm: None,
             auth: None,
         };
         let cfg = to_tools_config(&tool);
@@ -1402,6 +1417,9 @@ mod tests {
                 serde_yaml::to_value(serde_json::json!({ "parent": "organizations/42" })).unwrap(),
             ),
             poll: None,
+            endpoint: None,
+            stack: None,
+            confirm: None,
             auth: None,
         };
         let vars = empty_vars();
@@ -1438,6 +1456,9 @@ mod tests {
                 .unwrap(),
             ),
             poll: None,
+            endpoint: None,
+            stack: None,
+            confirm: None,
             auth: None,
         };
         let vars = empty_vars();

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -1182,6 +1182,9 @@ impl PlaybookRunner {
                 dry_run,
                 input,
                 poll,
+                endpoint,
+                stack,
+                confirm,
                 auth,
             } => {
                 // Render every template in the provider block with the CLI's
@@ -1210,6 +1213,18 @@ impl PlaybookRunner {
                     Some(s) => Some(self.render_template(s, context)?),
                     None => None,
                 };
+                let rendered_endpoint = match endpoint {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
+                let rendered_stack = match stack {
+                    Some(s) => Some(self.render_template(s, context)?),
+                    None => None,
+                };
+                let rendered_confirm = match confirm {
+                    Some(s) => Some(self.render_template(s, context)?),
+                    None => None,
+                };
 
                 if self.verbose {
                     eprintln!("   ☁️  Executing provider action: {}", action);
@@ -1226,6 +1241,9 @@ impl PlaybookRunner {
                     dry_run: rendered_dry_run,
                     input: rendered_input,
                     poll: rendered_poll,
+                    endpoint: rendered_endpoint,
+                    stack: rendered_stack,
+                    confirm: rendered_confirm,
                     auth: rendered_auth,
                 };
                 let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {


### PR DESCRIPTION
Round 3 CLI side of the cloud provider tool (noetl/ai-meta#189). Extends the local-runtime provider dispatch so the three new round-3 fields reach the noetl-tools `ProviderTool` in `noetl exec --runtime local`.

## What changed
- **`Tool::Provider`** (executor/src/playbook.rs) gains `endpoint` / `stack` / `confirm`.
- **`tools_bridge`** config assembly forwards them into the ProviderSpec config body.
- **`playbook_runner`** renders + reconstructs them in the local dispatch arm.

## Fields
- `endpoint` — config-level API endpoint override (testing / emulators only); lets a playbook be validated offline against wiremock / an emulator.
- `stack` — ownership / stack label for the EHDB resource-ownership projection (Fork 1).
- `confirm` — destroy confirmation digest for the confirm-gated destroy path (Fork 2).

## Sequencing
Compiles clean against the **published noetl-tools 3.22.0** (serde ignores the unknown config keys), so this lands independently. The round-3 behavior activates once noetl-tools 3.23 releases (noetl/tools#88) and the cli re-pins — the same follow-up sequencing round 2 used for the 3.22 apply-mode re-pin.

## Local-mode proof
A `noetl exec --runtime local` run of a provider apply-mode step with `endpoint` pointed at a local mock issued the GET-first converge against the mock (service reported ENABLED → no-op `changed:false`), zero live cloud calls. Proof used a temporary uncommitted `[patch]` onto the round-3 noetl-tools branch; the mock access log confirmed the apply-mode GET routed to the override endpoint.

Depends on noetl/tools#88 for the runtime behavior. Refs noetl/ai-meta#189