### PR TITLE
feat(provider): local-mode passthrough for reconcile policy + known_desired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2985,9 +2985,9 @@ checksum = "fcdc9657471e917de19608a327a65eafb0d4bef5df5271c991c85982a5ccdf07"
 
 [[package]]
 name = "noetl-tools"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec268353dcf60add6a3b38c0832d182f0e6c7535fac5395c79cb71ddb9821fdf"
+checksum = "fb6498abf0cf9b3f669e89692421b95eda9db5a343471be645485650a60942b6"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,20 +73,20 @@ duckdb-integration = ["noetl-tools/duckdb-integration"]
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.6" }
+noetl-executor = { path = "executor", version = "0.7" }
 
 # noetl/ai-meta#90 Phase 6 — the `noetl subscribe` local-mode listener
 # reuses the same source clients (`build_source`), header-directive engine,
 # and store-and-forward spool engine the in-cluster worker runtime uses, so
 # the event model is identical across CLI-local / in-cluster / Cloud Run.
-# `noetl-tools` "3.23" pins the round-3 provider surface (confirm-gated
-# destroy + endpoint override + ownership fact/`provider_state` fold) so
-# `noetl exec --runtime local` runs the same round-3 tool the worker does —
-# not just the field passthrough against 3.22.0.  Default features pull in the
-# pubsub + kafka + gcs source/backends.  `noetl-events` is the shared
-# `EventSink` trait + `ExecutorEvent` envelope the local `FileEventSink`
-# implements (same wire shape as the worker's NATS/HTTP sinks).
-noetl-tools = "3.23"
+# `noetl-tools` "3.24" pins the round-4 provider surface (reconcile policy
+# report/enforce/adopt + confirm-gated drift adoption) so
+# `noetl exec --runtime local` runs the same round-4 tool the worker does —
+# not just the `reconcile`/`known_desired` field passthrough against 3.23.
+# Default features pull in the pubsub + kafka + gcs source/backends.
+# `noetl-events` is the shared `EventSink` trait + `ExecutorEvent` envelope the
+# local `FileEventSink` implements (same wire shape as the worker's NATS/HTTP sinks).
+noetl-tools = "3.24"
 noetl-events = { path = "events", version = "0.1.0" }
 async-trait = "0.1"
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,5 +1,15 @@
 [package]
 name = "noetl-executor"
+# 0.7.0 — noetl/ai-meta#189 provider tool round 4 (drift adoption).  Adds
+# `reconcile` + `known_desired` fields to the `Tool::Provider` variant of
+# `playbook::Tool`.  New public fields on a non-#[non_exhaustive] struct
+# variant are a breaking API change → minor bump under 0.x SemVer.  Per the
+# 0.6.0 note below, this bump is LOAD-BEARING for the release: executor 0.6.0
+# is already on crates.io *without* these fields, and the `publish-crate` job
+# skips republishing an existing version — so leaving 0.6.0 would make the
+# `noetl` bin resolve the round-4-less executor from crates.io and ship the
+# reconcile/adopt surface dead.
+#
 # 0.6.0 — noetl/ai-meta#189 provider tool.  Adds the `Tool::Provider`
 # variant to `playbook::Tool` (cli commits 75edc68 + 8436790, shipped in
 # noetl v4.14.0 / v4.15.0).  `Tool` is a plain (non-#[non_exhaustive])
@@ -18,7 +28,7 @@ name = "noetl-executor"
 # replaces _prev/_results injection with explicit set:/input: forward-
 # only data binding.  Bumped from noetl-tools "2.21" → "3" so both the
 # CLI and noetl-worker resolve to the same major version.
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"

--- a/executor/src/playbook.rs
+++ b/executor/src/playbook.rs
@@ -414,10 +414,20 @@ pub enum Tool {
         /// ownership + drift + orphan projection.
         #[serde(default)]
         stack: Option<String>,
-        /// Destroy confirmation digest (Round 3, Fork 2) — required to apply a
-        /// destroy verb; must equal the `plan_digest` from a reviewed dry-run.
+        /// Destroy / adopt confirmation digest (Round 3 destroy + Round 4 adopt)
+        /// — required to apply a destroy verb or an `adopt`; must equal the
+        /// `plan_digest` from a reviewed dry-run.
         #[serde(default)]
         confirm: Option<String>,
+        /// Reconciliation policy (Round 4) — `report` (default) / `enforce` /
+        /// `adopt`.  Governs how a drifted mutating ensure action is handled.
+        #[serde(default)]
+        reconcile: Option<String>,
+        /// Last-known-desired spec for this resource's URN (Round 4), supplied by
+        /// the caller's EHDB raw-eventlog-tier fold.  Used by `report` / `adopt`
+        /// to compute the desired-vs-actual diff; absent → untracked / import.
+        #[serde(default)]
+        known_desired: Option<serde_yaml::Value>,
         /// Provider auth block (apply mode only).  Captured raw and mapped to
         /// the noetl-tools `AuthConfig` at dispatch; dry-run ignores it.
         #[serde(default)]

--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -353,6 +353,8 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             endpoint,
             stack,
             confirm,
+            reconcile,
+            known_desired,
             // `auth` is mapped to ToolConfig.auth in the dispatch arm, not into
             // the config body (the ProviderSpec ignores an `auth` config key).
             auth: _,
@@ -386,6 +388,12 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             }
             if let Some(c) = confirm {
                 cfg.insert("confirm".into(), serde_json::json!(c));
+            }
+            if let Some(r) = reconcile {
+                cfg.insert("reconcile".into(), serde_json::json!(r));
+            }
+            if let Some(k) = known_desired {
+                cfg.insert("known_desired".into(), yaml_to_json(k));
             }
             ("provider", serde_json::Value::Object(cfg))
         }
@@ -1363,6 +1371,8 @@ mod tests {
             endpoint: None,
             stack: None,
             confirm: None,
+            reconcile: None,
+            known_desired: None,
             auth: None,
         };
         let cfg = to_tools_config(&tool);
@@ -1420,6 +1430,8 @@ mod tests {
             endpoint: None,
             stack: None,
             confirm: None,
+            reconcile: None,
+            known_desired: None,
             auth: None,
         };
         let vars = empty_vars();
@@ -1459,6 +1471,8 @@ mod tests {
             endpoint: None,
             stack: None,
             confirm: None,
+            reconcile: None,
+            known_desired: None,
             auth: None,
         };
         let vars = empty_vars();

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -1185,6 +1185,8 @@ impl PlaybookRunner {
                 endpoint,
                 stack,
                 confirm,
+                reconcile,
+                known_desired,
                 auth,
             } => {
                 // Render every template in the provider block with the CLI's
@@ -1225,6 +1227,14 @@ impl PlaybookRunner {
                     Some(s) => Some(self.render_template(s, context)?),
                     None => None,
                 };
+                let rendered_reconcile = match reconcile {
+                    Some(s) => Some(self.render_template(s, context)?),
+                    None => None,
+                };
+                let rendered_known_desired = match known_desired {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
 
                 if self.verbose {
                     eprintln!("   ☁️  Executing provider action: {}", action);
@@ -1244,6 +1254,8 @@ impl PlaybookRunner {
                     endpoint: rendered_endpoint,
                     stack: rendered_stack,
                     confirm: rendered_confirm,
+                    reconcile: rendered_reconcile,
+                    known_desired: rendered_known_desired,
                     auth: rendered_auth,
                 };
                 let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {


### PR DESCRIPTION
## Round 4 — drift adoption (CLI local-mode passthrough)

Round 4 of the cloud provider tool (`kind: provider`), tracking
**noetl/ai-meta#189**. Sibling of noetl/tools#89 (the tool logic).

Extends the executor `Tool::Provider` + `tools_bridge` + `playbook_runner`
with two new pass-through fields so the round-4 drift-adoption surface
reaches the noetl-tools `ProviderTool` in `noetl exec --runtime local`
(the same tool the worker runs):

- **`reconcile`** — `report` (default) / `enforce` / `adopt`.
- **`known_desired`** — last-known-desired for the resource's URN, from the caller's EHDB raw-eventlog-tier fold; used by `report`/`adopt` to compute the desired-vs-actual diff.

Both are rendered through the CLI's template engine (same contract as the
existing `endpoint`/`stack`/`confirm` fields) then handed to the tool via
the bridge. Purely additive (38 insertions, 2 deletions).

Compiles clean against published **noetl-tools 3.23.0** (serde ignores the
unknown keys); round-4 behavior activates once tools **3.24.0** releases
and the pin bumps — same sequencing as rounds 2-3. Zero new clippy warnings.

### Local-mode proof (built against the local round-4 tools; no live cloud, no mutation)
Against a mock GCP endpoint serving a project drifted out-of-band
(`parent: folders/1 → folders/2`, display renamed):

```
# report (default) — drift diff, NO ownership fact, changed:false
{ "reconcile":"report", "drift":{"drift":"modified","fields":["display_name","parent"]},
  "diff":{"parent":{"desired":"folders/1","actual":"folders/2"}, ...}, "changed":false }
  # (no provider_fact key)

# adopt dry-run — field-by-field diff + plan_digest, provider_fact outcome "planned"
{ "reconcile":"adopt","dry_run":true,"changed":false,
  "plan_digest":"9bfc902328f96d049951fe1cc0020a31213ba7ac4d76bb71cb4fa4ebb9b43fcb",
  "diff":{...}, "provider_fact":{"verb":"adopt","outcome":"planned"} }

# adopt apply, matching confirm @ etag E1 — ADOPTED, mock log shows GET only (zero writes)
{ "reconcile":"adopt","adopted":true,"changed":false,
  "provider_fact":{"verb":"adopt","outcome":"adopted","desired":{"parent":"folders/2",...}} }

# adopt apply, STALE E1 confirm after mock drifts to etag E2 — REFUSED
Error: adopt apply REFUSED ...: the supplied confirm digest (9bfc9023...) does not match the
live-resolved actual digest (1b155f80...). The resource changed again since the diff was
reviewed ... No state was written.
```

Mock access log across every apply showed **GET-only, zero writes** —
adopt is provably non-mutating.

See noetl/ai-meta#189