### PR TITLE
fix(release): bump noetl-executor to 0.6.0 so Tool::Provider publishes to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,7 +462,9 @@ jobs:
           git push origin HEAD:main
       - name: Skip tap publish
         if: ${{ steps.homebrew_token.outputs.usable == 'false' }}
-        run: echo "HOMEBREW_TAP_PUSH_TOKEN is not set or cannot access noetl/homebrew-tap; skipping Homebrew tap update."
+        run: |
+          echo "::warning title=Homebrew tap not updated::HOMEBREW_TAP_PUSH_TOKEN is not set or cannot access noetl/homebrew-tap; skipping Homebrew tap update. The tap formula was NOT bumped for this release. Set/authorize the secret to publish."
+          echo "HOMEBREW_TAP_PUSH_TOKEN is not set or cannot access noetl/homebrew-tap; skipping Homebrew tap update."
 
   update-apt-repo:
     runs-on: ubuntu-latest
@@ -524,4 +526,6 @@ jobs:
           git push origin HEAD:main
       - name: Skip APT publish
         if: ${{ steps.apt_token.outputs.usable == 'false' }}
-        run: echo "APT_REPO_PUSH_TOKEN is not set or cannot access noetl/apt; skipping APT repo update."
+        run: |
+          echo "::warning title=APT repo not updated::APT_REPO_PUSH_TOKEN is not set or cannot access noetl/apt; skipping APT repo update. The .deb was attached to the GitHub release but the apt repository index was NOT updated for this release. Set/authorize the secret to publish."
+          echo "APT_REPO_PUSH_TOKEN is not set or cannot access noetl/apt; skipping APT repo update."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ duckdb-integration = ["noetl-tools/duckdb-integration"]
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.5" }
+noetl-executor = { path = "executor", version = "0.6" }
 
 # noetl/ai-meta#90 Phase 6 — the `noetl subscribe` local-mode listener
 # reuses the same source clients (`build_source`), header-directive engine,

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,11 +1,24 @@
 [package]
 name = "noetl-executor"
+# 0.6.0 — noetl/ai-meta#189 provider tool.  Adds the `Tool::Provider`
+# variant to `playbook::Tool` (cli commits 75edc68 + 8436790, shipped in
+# noetl v4.14.0 / v4.15.0).  `Tool` is a plain (non-#[non_exhaustive])
+# enum, so a new variant is a breaking API change → minor bump under 0.x
+# SemVer.  THIS BUMP IS LOAD-BEARING FOR THE RELEASE: the source gained
+# the variant in v4.14.0 but the version stayed 0.5.0, which was already
+# on crates.io *without* the variant.  The release-cli `publish-crate`
+# job skips republishing an existing version, so the `noetl` bin's
+# `cargo publish` verify build kept resolving noetl-executor 0.5.0 from
+# crates.io and failing with `E0599: no variant named Provider`.  Any
+# future change to this crate's public surface MUST bump this version in
+# the same change set, or the bin publish silently breaks again.
+#
 # 0.5.0 — noetl/ai-meta#77 (explicit input:/set: forward-only data
 # binding).  noetl-tools v3.0.0 is a breaking change: TaskSequenceTool
 # replaces _prev/_results injection with explicit set:/input: forward-
 # only data binding.  Bumped from noetl-tools "2.21" → "3" so both the
 # CLI and noetl-worker resolve to the same major version.
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"


### PR DESCRIPTION
## Problem

The `release-cli` workflow has shown a **red run on the last two releases**
(v4.14.0, v4.15.0). The failing job is **`publish-crate`** (`cargo publish`
to crates.io) — *not* the binary or apt jobs. `build-deb`,
`build-release-assets` (×3), `github-release` all succeed, so the tarballs
and `.deb` are attached to every GitHub release. Only the crates.io publish
is broken.

Failing runs: [`29283160094`](https://github.com/noetl/cli/actions/runs/29283160094),
[`29274994872`](https://github.com/noetl/cli/actions/runs/29274994872).

```
error[E0599]: no variant named `Provider` found for enum
`noetl_executor::playbook::Tool`
  --> src/playbook_runner.rs:1177:19
error: failed to verify package tarball
```

## Root cause

`noetl-executor` gained the `Tool::Provider` enum variant in commit
`75edc68` (the `kind: provider` work, shipped in v4.14.0) — but the crate's
version stayed **`0.5.0`**, and crates.io already had `noetl-executor 0.5.0`
published *before* the variant existed.

The `publish-crate` job skips republishing a version that already exists on
crates.io, so it never uploaded the variant-carrying source. When it then
publishes the `noetl` bin, `cargo publish`'s verify build resolves
`noetl-executor = "0.5"` to the **stale 0.5.0 from crates.io** (path deps are
stripped on publish) and fails to find `Tool::Provider`.

Last successful crate publish was **v4.13.0** — the last release before the
provider variant landed. The binaries build from the workspace (path dep, has
the variant) which is why they're green.

`Tool` is a plain, non-`#[non_exhaustive]` enum, so adding a variant is a
breaking API change → minor bump under 0.x SemVer.

## Fix

- `executor/Cargo.toml`: version `0.5.0` → **`0.6.0`**.
- `Cargo.toml`: `noetl-executor` dep constraint `"0.5"` → **`"0.6"`** (forces
  the verify build to resolve the variant-carrying version; can never fall
  back to stale 0.5.0).
- `Cargo.lock`: regenerated (`noetl-executor 0.6.0`).

The publish job already publishes `noetl-executor` *before* the `noetl` bin,
so on the next release executor 0.6.0 lands first and the bin resolves it.

### DuckDB — not the cause, deliberately unchanged

DuckDB compiled fine in the failing logs and is already feature-gated
(`noetl-tools ≥3.20.0` gates `libduckdb-sys` behind `duckdb-integration`, per
noetl/ai-meta#185; `noetl-executor` defaults it off). The CLI keeps it in
`default` because users need DuckDB in the binary and it shares the same
`libduckdb-sys` node via feature unification (zero extra build cost). No
change made here.

### Secondary: silent apt / homebrew skips made visible

`update-apt-repo` and `update-homebrew-tap` finish in ~3–4s and hit their
**"Skip"** step (`usable=false`) — the `APT_REPO_PUSH_TOKEN` /
`HOMEBREW_TAP_PUSH_TOKEN` secrets are missing or lack access. The jobs go
**green while publishing nothing**: the `noetl/apt` repo `main` index is
frozen at `2.13.0` (no 4.x `.deb` ever landed) and the homebrew tap isn't
bumped. This PR adds a `::warning::` annotation to those skip steps so the
gap is visible on the run summary. **Resolving it requires a maintainer to
set/authorize those secrets — not doable in this PR.**

## Verification

- `cargo publish -p noetl-executor --dry-run` — packages and verify-compiles
  **0.6.0** against the crates.io deps (`noetl-events 0.1.0`,
  `noetl-tools 3.23.0`); reaches the upload step, **exit 0**.
- `cargo metadata` — workspace resolves `noetl 4.15.0 → noetl-executor 0.6.0`.
- Local toolchain `rustc 1.91.1 (ed61e7d7e)` matches the CI stable that
  produced the failure.
- Workflow YAML re-validated.

**Not verifiable pre-merge:** the `noetl` bin's `cargo publish` verify build
against the *registry* executor 0.6.0 can only run in CI after 0.6.0 is
uploaded (chicken-and-egg, inherent to the two-stage publish — same as every
prior green release). Proven here: executor 0.6.0 is publishable, it carries
`Tool::Provider`, and the bin compiles against it locally. Merging emits a
`fix:` → semantic-release cuts v4.15.1 → the release runs end-to-end and
publishes executor 0.6.0 + the bin to crates.io.

## Artifact backfill (no history rewrite)

- **crates.io** missing 4.14.0 / 4.15.0 (this bug) + 4.8.0 / 4.11.0 (older,
  separate transient failures). These self-heal on the **next release**
  (v4.15.1) — no tag rewrite or force-push proposed.
- **v4.11.0** GitHub release has zero binary assets (2026-06-12 `async-nats`
  E0119 build break, since fixed). Superseded by 4.12–4.15; recommend leaving.
- **apt / homebrew** backfill for 4.15.x happens automatically once the
  secrets are set and a release runs.

Refs noetl/ai-meta#190