### PR TITLE
ci(release): regenerate every apt suite (jammy + noble) from a data-driven loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,11 +546,23 @@ jobs:
         run: |
           set -euo pipefail
           cd apt
-          mkdir -p pool/main dists/jammy/main/binary-amd64
+          # Ubuntu suites served from the shared pool/main.  Add a new
+          # codename here (e.g. plucky) and it is indexed on the next
+          # release automatically -- no per-suite block to copy.  This loop
+          # replaces a hardcoded jammy-only block; dists/noble silently
+          # rotted at 2.13.0 for months because the old block only ever
+          # regenerated jammy while the .deb landed in the shared pool.
+          DISTS="jammy noble"
+          mkdir -p pool/main
           cp ../dist/*.deb pool/main/
-          dpkg-scanpackages pool/main /dev/null > dists/jammy/main/binary-amd64/Packages
-          gzip -9c dists/jammy/main/binary-amd64/Packages > dists/jammy/main/binary-amd64/Packages.gz
-          apt-ftparchive release dists/jammy > dists/jammy/Release
+          for DIST in ${DISTS}; do
+            mkdir -p "dists/${DIST}/main/binary-amd64"
+            dpkg-scanpackages pool/main /dev/null \
+              > "dists/${DIST}/main/binary-amd64/Packages"
+            gzip -9c "dists/${DIST}/main/binary-amd64/Packages" \
+              > "dists/${DIST}/main/binary-amd64/Packages.gz"
+            apt-ftparchive release "dists/${DIST}" > "dists/${DIST}/Release"
+          done
       - name: Commit and push
         if: ${{ steps.apt_token.outputs.usable == 'true' }}
         shell: bash


### PR DESCRIPTION
## Why

`update-apt-repo` only ever rebuilt `dists/jammy`. The `.deb` lands in the **shared** `pool/main` (both suites reference it), but nothing regenerated `dists/noble`'s index — so noble silently froze at **noetl 2.13.0** (index dated 2026-05-03) while jammy advanced. Ubuntu 24.04 users following the **advertised** `noble` line in the apt `README` got a three-major-versions-stale package.

This is a second, pre-existing bug, separate from the dead-token issue fixed in #69. It surfaced during the 4.16.0 backfill: jammy went to 4.16.0, noble stayed at 2.13.0.

## What this changes

Replaces the hardcoded jammy-only block with a loop over `DISTS="jammy noble"` that, for each suite, scans the shared pool and regenerates `Packages`, `Packages.gz`, and `Release`:

```bash
DISTS="jammy noble"
mkdir -p pool/main
cp ../dist/*.deb pool/main/
for DIST in ${DISTS}; do
  mkdir -p "dists/${DIST}/main/binary-amd64"
  dpkg-scanpackages pool/main /dev/null > "dists/${DIST}/main/binary-amd64/Packages"
  gzip -9c "dists/${DIST}/main/binary-amd64/Packages" > "dists/${DIST}/main/binary-amd64/Packages.gz"
  apt-ftparchive release "dists/${DIST}" > "dists/${DIST}/Release"
done
```

The per-suite commands are **byte-identical to the proven jammy path** — just looped. Adding a future codename (e.g. `plucky`) is now a one-word edit instead of a copy-pasted block someone has to remember, which is exactly how noble rotted.

## Scope / safety

- **No rebuild** — the 4.16.0 `.deb` is already in `pool/main`; this only regenerates per-suite indices.
- **Repo stays unsigned** (`[trusted=yes]` per the apt README; no `InRelease`/`Release.gpg` exist). No signing introduced — out of scope.
- Release files stay minimal, matching the existing jammy output (`apt-ftparchive release` with no config). With `[trusted=yes]`, apt does not require Suite/Codename fields — jammy has served this way successfully. Enriching Release metadata is a possible follow-up, deliberately not bundled to avoid unproven `apt-ftparchive` options in the live release path.
- `jammy` output is unchanged (same command), so it does not regress.

## Validation

- `actionlint` clean (exit 0); YAML parses.
- Loop body simulated end-to-end with stub `dpkg-scanpackages` / `apt-ftparchive` against a seeded `pool/main`: both `dists/jammy` and `dists/noble` get regenerated `Packages` (containing 4.16.0), `Packages.gz`, and a fresh-dated `Release`; `Filename:` paths resolve to `pool/main`; exit 0.
- Post-merge: a `release-cli` re-dispatch at 4.16.0 will backfill noble; ground truth (noble serving `noetl 4.16.0-1` with a resolving SHA256, jammy still 4.16.0) will be verified before closing the tracking issue.

Refs noetl/ai-meta#190 — closed manually after the re-dispatch verifies both suites (cross-repo `Closes` from a cli PR wouldn't auto-close an ai-meta issue regardless).