### PR TITLE
feat(provider): wrong-target guard wiring + git-backed state sink (--facts-out)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-executor"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2985,9 +2985,9 @@ checksum = "fcdc9657471e917de19608a327a65eafb0d4bef5df5271c991c85982a5ccdf07"
 
 [[package]]
 name = "noetl-tools"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96008fe4a2ae4926f5a77e7e59ed9ff05d44ab1fad6057e314043fa8c858eb29"
+checksum = "2f50b3b0f87ec82da0232ef926db18faebd9b277938104e62ab391e1af6c3d71"
 dependencies = [
  "anyhow",
  "arrow 53.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ duckdb-integration = ["noetl-tools/duckdb-integration"]
 # dev uses the path; `cargo publish` resolves against the crates.io
 # version constraint.  R-1.2 PR-1 set the executor's `publish = true`
 # so this dependency can be satisfied from crates.io.
-noetl-executor = { path = "executor", version = "0.7" }
+noetl-executor = { path = "executor", version = "0.8" }
 
 # noetl/ai-meta#90 Phase 6 — the `noetl subscribe` local-mode listener
 # reuses the same source clients (`build_source`), header-directive engine,
@@ -89,7 +89,7 @@ noetl-executor = { path = "executor", version = "0.7" }
 # Default features pull in the pubsub + kafka + gcs source/backends.
 # `noetl-events` is the shared `EventSink` trait + `ExecutorEvent` envelope the
 # local `FileEventSink` implements (same wire shape as the worker's NATS/HTTP sinks).
-noetl-tools = "3.25"
+noetl-tools = "3.26"
 noetl-events = { path = "events", version = "0.1.0" }
 async-trait = "0.1"
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -28,7 +28,7 @@ name = "noetl-executor"
 # replaces _prev/_results injection with explicit set:/input: forward-
 # only data binding.  Bumped from noetl-tools "2.21" → "3" so both the
 # CLI and noetl-worker resolve to the same major version.
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/cli"
@@ -88,7 +88,7 @@ rhai = { version = "1.18", features = ["sync"] }
 # Subsequent sub-PRs (PR-2c-2 onwards per Strategy B) replace one
 # inline tool implementation in playbook_runner.rs at a time so
 # semantic differences surface incrementally instead of all at once.
-noetl-tools = "3"
+noetl-tools = "3.26"
 
 # GCS uploads in `tools_bridge::gcs_upload` (R-3 GCS sink migration,
 # noetl/ai-meta#31).  The `gcp` feature pulls in

--- a/executor/src/playbook.rs
+++ b/executor/src/playbook.rs
@@ -428,6 +428,12 @@ pub enum Tool {
         /// to compute the desired-vs-actual diff; absent → untracked / import.
         #[serde(default)]
         known_desired: Option<serde_yaml::Value>,
+        /// Multi-org / multi-billing wrong-target guard (Stage-1 safety) —
+        /// `{ require_org, require_org_display_name, require_billing_account }`.
+        /// Pins the organization + billing account a run may touch; a mismatch
+        /// is refused structurally (offline) and, in apply mode, live.
+        #[serde(default)]
+        guard: Option<serde_yaml::Value>,
         /// Provider auth block (apply mode only).  Captured raw and mapped to
         /// the noetl-tools `AuthConfig` at dispatch; dry-run ignores it.
         #[serde(default)]

--- a/executor/src/tools_bridge.rs
+++ b/executor/src/tools_bridge.rs
@@ -355,6 +355,7 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             confirm,
             reconcile,
             known_desired,
+            guard,
             // `auth` is mapped to ToolConfig.auth in the dispatch arm, not into
             // the config body (the ProviderSpec ignores an `auth` config key).
             auth: _,
@@ -394,6 +395,9 @@ pub fn to_tools_config(tool: &Tool) -> ToolConfig {
             }
             if let Some(k) = known_desired {
                 cfg.insert("known_desired".into(), yaml_to_json(k));
+            }
+            if let Some(g) = guard {
+                cfg.insert("guard".into(), yaml_to_json(g));
             }
             ("provider", serde_json::Value::Object(cfg))
         }
@@ -1373,6 +1377,7 @@ mod tests {
             confirm: None,
             reconcile: None,
             known_desired: None,
+            guard: None,
             auth: None,
         };
         let cfg = to_tools_config(&tool);
@@ -1432,6 +1437,7 @@ mod tests {
             confirm: None,
             reconcile: None,
             known_desired: None,
+            guard: None,
             auth: None,
         };
         let vars = empty_vars();
@@ -1473,6 +1479,7 @@ mod tests {
             confirm: None,
             reconcile: None,
             known_desired: None,
+            guard: None,
             auth: None,
         };
         let vars = empty_vars();

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,12 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
 
+        /// Git-backed state sink: append each successful `kind: provider` apply's
+        /// ownership fact to this JSONL file (sensitive identifiers masked).
+        /// Read back with `noetl provider drift/orphans --facts-file <path>`.
+        #[arg(long)]
+        facts_out: Option<PathBuf>,
+
         /// Emit only JSON response (distributed runtime)
         #[arg(short, long)]
         json: bool,
@@ -2379,6 +2385,7 @@ async fn main() -> Result<()> {
             endpoint,
             verbose,
             dry_run,
+            facts_out,
             json,
         }) => {
             // Get context runtime preference (honours --context override).
@@ -2453,6 +2460,7 @@ async fn main() -> Result<()> {
                         .with_variables(vars)
                         .with_verbose(verbose)
                         .with_target(effective_target)
+                        .with_facts_out(facts_out.clone())
                         // When --json is set, suppress progress entirely
                         // so stdout = ONLY the JSON envelope. The user
                         // still sees errors via stderr.

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -89,6 +89,10 @@ pub struct PlaybookRunner {
     /// → progress on stderr (or nothing in --quiet), structured JSON
     /// envelope on stdout.
     emit_json: bool,
+    /// Git-backed state sink (`noetl exec --facts-out <path>`): after each
+    /// successful provider-step apply, the emitted `provider_fact` is appended
+    /// as JSONL (sensitive identifiers masked).  `None` disables persistence.
+    facts_out: Option<PathBuf>,
 }
 
 impl PlaybookRunner {
@@ -101,7 +105,13 @@ impl PlaybookRunner {
             merge: false,
             quiet: false,
             emit_json: false,
+            facts_out: None,
         }
+    }
+
+    pub fn with_facts_out(mut self, facts_out: Option<PathBuf>) -> Self {
+        self.facts_out = facts_out;
+        self
     }
 
     pub fn with_variables(mut self, vars: HashMap<String, String>) -> Self {
@@ -1187,6 +1197,7 @@ impl PlaybookRunner {
                 confirm,
                 reconcile,
                 known_desired,
+                guard,
                 auth,
             } => {
                 // Render every template in the provider block with the CLI's
@@ -1235,6 +1246,10 @@ impl PlaybookRunner {
                     Some(v) => Some(self.render_yaml_value(v, context)?),
                     None => None,
                 };
+                let rendered_guard = match guard {
+                    Some(v) => Some(self.render_yaml_value(v, context)?),
+                    None => None,
+                };
 
                 if self.verbose {
                     eprintln!("   ☁️  Executing provider action: {}", action);
@@ -1256,6 +1271,7 @@ impl PlaybookRunner {
                     confirm: rendered_confirm,
                     reconcile: rendered_reconcile,
                     known_desired: rendered_known_desired,
+                    guard: rendered_guard,
                     auth: rendered_auth,
                 };
                 let bridge_ctx = noetl_executor::tools_bridge::BridgeContext {
@@ -1274,6 +1290,15 @@ impl PlaybookRunner {
                         ),
                     )
                 })?;
+                // Git-backed state sink: persist the applied ownership fact.
+                // `outcome.result` is a JSON-serialized string; parse it, then
+                // `append_applied_fact` skips planned/dry-run outcomes (so a plan
+                // run writes nothing).
+                if let (Some(out), Some(data_str)) = (&self.facts_out, outcome.result.as_ref()) {
+                    if let Ok(data) = serde_json::from_str::<serde_json::Value>(data_str) {
+                        crate::provider_cli::append_applied_fact(out, &data)?;
+                    }
+                }
                 Ok(outcome.result)
             }
             Tool::Unsupported => {

--- a/src/provider_cli.rs
+++ b/src/provider_cli.rs
@@ -102,11 +102,19 @@ pub struct ProviderCommonArgs {
     /// prior state, or use `--facts-file` for an offline state source.
     #[arg(long)]
     pub server: Option<String>,
-    /// Offline last-known-desired source: a JSON file of raw eventlog-tier
-    /// records (or event bodies, or bare provider_facts).  Mutually exclusive
-    /// with `--server`.
+    /// Offline last-known-desired source: a file of raw eventlog-tier records
+    /// (or event bodies, or bare provider_facts).  Accepts either a JSON array
+    /// or newline-delimited JSON (JSONL — the append format `--facts-out`
+    /// writes).  Mutually exclusive with `--server`.
     #[arg(long)]
     pub facts_file: Option<PathBuf>,
+    /// Append the emitted `provider_fact` to this JSONL file after a successful
+    /// apply (adopt / converge) — the EHDB-less git-backed state sink.  One
+    /// applied fact per line; `planned` / dry-run outcomes are not written.
+    /// Read back with `--facts-file <same path>`.  The billing-account id and
+    /// IAM member identifiers are masked so a committed file stays clean.
+    #[arg(long)]
+    pub facts_out: Option<PathBuf>,
     /// Restrict the eventlog-tier fetch to one execution id.
     #[arg(long)]
     pub execution: Option<String>,
@@ -358,6 +366,10 @@ async fn adopt(
         .with_context(|| format!("adopt: dispatching provider step {:?}", target.step))?;
     let data = res.data.unwrap_or(serde_json::Value::Null);
 
+    // Git-backed state sink: an applied adopt writes an ownership fact.  Dry-run
+    // (outcome `planned`) is filtered out inside the helper.
+    maybe_append_applied_fact(common, &data)?;
+
     if common.json {
         print_json(&serde_json::json!({ "verb": "adopt", "step": target.step, "result": data }));
     } else if apply {
@@ -411,6 +423,92 @@ fn load_resources(path: &Path) -> Result<Vec<DeclaredResource>> {
         );
     }
     Ok(out)
+}
+
+/// Parse a facts file that is EITHER a JSON array (the historical form) OR
+/// newline-delimited JSON (JSONL — what `--facts-out` appends).  Detected by the
+/// first non-whitespace byte: `[` → array; otherwise parse each non-empty line.
+fn parse_facts_content(content: &str) -> Result<Vec<serde_json::Value>> {
+    let trimmed = content.trim_start();
+    if trimmed.starts_with('[') {
+        return Ok(serde_json::from_str(content)?);
+    }
+    let mut out = Vec::new();
+    for (i, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line)
+            .with_context(|| format!("parsing JSONL line {}", i + 1))?;
+        out.push(v);
+    }
+    Ok(out)
+}
+
+/// Append one `provider_fact` to a JSONL file (create-if-absent, O_APPEND),
+/// masking the non-secret-but-policy-sensitive identifiers so a committed file
+/// stays clean.  Called only after a successful APPLY with an applied outcome.
+fn append_fact_jsonl(path: &Path, fact: &serde_json::Value) -> Result<()> {
+    use std::io::Write;
+    // Wrap under `provider_fact` so the read side (`fact_in_record`, which looks
+    // at `provider_fact` / `data.provider_fact` / `result.data.provider_fact`)
+    // recognizes each JSONL line.  Mask sensitive identifiers first.
+    let record = serde_json::json!({ "provider_fact": mask_fact_identifiers(fact) });
+    let mut line = serde_json::to_string(&record)?;
+    line.push('\n');
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening facts-out file {}", path.display()))?;
+    f.write_all(line.as_bytes())
+        .with_context(|| format!("appending to facts-out file {}", path.display()))?;
+    Ok(())
+}
+
+/// Mask the two identifiers that can appear in a fact's `desired` and are kept
+/// out of git by policy (neither is a credential): the billing account id and
+/// the IAM member email.  Everything else (URN, folder/project/service ids) is
+/// commit-safe.
+fn mask_fact_identifiers(fact: &serde_json::Value) -> serde_json::Value {
+    let mut f = fact.clone();
+    if let Some(desired) = f.get_mut("desired").and_then(|d| d.as_object_mut()) {
+        for k in [
+            "billing_account",
+            "billingAccount",
+            "billingAccountName",
+            "member",
+        ] {
+            if desired.contains_key(k) {
+                desired.insert(k.to_string(), serde_json::json!("<masked>"));
+            }
+        }
+    }
+    f
+}
+
+/// Append the applied `provider_fact` from a tool result to the JSONL sink, iff
+/// the outcome is an applied one (`planned` / dry-run is intent-only and is
+/// skipped).  Shared by the provider verbs and `noetl exec --facts-out` so both
+/// dispatch paths persist ownership identically.
+pub(crate) fn append_applied_fact(out: &Path, data: &serde_json::Value) -> Result<()> {
+    let Some(fact) = data.get("provider_fact") else {
+        return Ok(());
+    };
+    let outcome = fact.get("outcome").and_then(|o| o.as_str()).unwrap_or("");
+    if matches!(outcome, "changed" | "noop" | "adopted" | "deleted" | "absent") {
+        append_fact_jsonl(out, fact)?;
+    }
+    Ok(())
+}
+
+/// `--facts-out` convenience for the provider verbs (wraps [`append_applied_fact`]).
+fn maybe_append_applied_fact(common: &ProviderCommonArgs, data: &serde_json::Value) -> Result<()> {
+    if let Some(out) = &common.facts_out {
+        append_applied_fact(out, data)?;
+    }
+    Ok(())
 }
 
 /// Build the noetl-tools ToolConfig for a resource, applying the CLI's stack /
@@ -469,8 +567,8 @@ async fn load_facts(client: &Client, common: &ProviderCommonArgs) -> Result<Vec<
     if let Some(path) = &common.facts_file {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("reading facts file {}", path.display()))?;
-        let records: Vec<serde_json::Value> =
-            serde_json::from_str(&content).with_context(|| format!("parsing facts file {}", path.display()))?;
+        let records = parse_facts_content(&content)
+            .with_context(|| format!("parsing facts file {}", path.display()))?;
         // Accept raw tier records (payload-string), decoded bodies, or bare
         // provider_facts — the tier extractor handles all three.
         return Ok(provider_state::extract_facts_from_tier_records(&records));
@@ -581,4 +679,86 @@ fn str_field(v: &serde_json::Value, key: &str) -> String {
 
 fn print_json(v: &serde_json::Value) {
     println!("{}", serde_json::to_string_pretty(v).unwrap_or_default());
+}
+
+#[cfg(test)]
+mod facts_sink_tests {
+    use super::*;
+
+    fn tmp_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("noetl-facts-{}-{}.jsonl", tag, std::process::id()))
+    }
+
+    #[test]
+    fn append_then_read_back_round_trip_and_masking() {
+        let path = tmp_path("rt");
+        let _ = std::fs::remove_file(&path);
+
+        // An applied adopt fact (ownership) + an applied billing fact whose
+        // `desired` carries the billing-account id that must be masked.
+        let adopt = serde_json::json!({
+            "urn": "google:cloudresourcemanager:project:shastara",
+            "provider": "google", "service": "cloudresourcemanager",
+            "resource_type": "project", "verb": "adopt", "stack": "shastaratech-org-foundation",
+            "outcome": "adopted", "execution_id": 1,
+            "desired": { "project_id": "shastara", "display_name": "shastara" }
+        });
+        let billing = serde_json::json!({
+            "urn": "google:cloudbilling:billing_link:shastaratech-youtube-prod",
+            "provider": "google", "service": "cloudbilling",
+            "resource_type": "billing_link", "verb": "ensure", "stack": "shastaratech-org-foundation",
+            "outcome": "changed", "execution_id": 2,
+            "desired": { "project_id": "shastaratech-youtube-prod", "billing_account": "billingAccounts/AAAAAA-BBBBBB-CCCCCC" }
+        });
+        // A planned (dry-run) fact that maybe_append_applied_fact must NOT write.
+        let planned = serde_json::json!({
+            "urn": "google:cloudresourcemanager:folder:20-media",
+            "provider": "google", "service": "cloudresourcemanager",
+            "resource_type": "folder", "verb": "ensure", "stack": "shastaratech-org-foundation",
+            "outcome": "planned", "execution_id": 3, "desired": { "display_name": "20-media" }
+        });
+
+        append_fact_jsonl(&path, &adopt).unwrap();
+        append_fact_jsonl(&path, &billing).unwrap();
+
+        // Masking: the committed line must not carry the billing account id.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("AAAAAA-BBBBBB-CCCCCC"), "billing account id must be masked in the sink");
+        assert!(raw.contains("<masked>"), "masked placeholder present");
+        assert_eq!(raw.lines().count(), 2, "one JSONL line per appended fact");
+
+        // Read back exactly as `--facts-file` does (JSONL) and fold → ownership.
+        let records = parse_facts_content(&raw).unwrap();
+        let facts = provider_state::extract_facts_from_tier_records(&records);
+        let model = provider_state::fold_facts(&facts);
+        assert!(
+            model.owned.contains_key("google:cloudresourcemanager:project:shastara"),
+            "adopted project is owned after the append→read-back round-trip"
+        );
+        assert!(
+            model.owned.contains_key("google:cloudbilling:billing_link:shastaratech-youtube-prod"),
+            "billing link is owned after round-trip (masking does not break the fold)"
+        );
+
+        // The planned/dry-run fact is filtered out by the apply-only gate.
+        let planned_data = serde_json::json!({ "provider_fact": planned });
+        let common = ProviderCommonArgs {
+            playbook: path.clone(), stack: None, server: None,
+            facts_file: None, facts_out: Some(path.clone()), execution: None,
+            endpoint: None, workload: None, json: false,
+        };
+        maybe_append_applied_fact(&common, &planned_data).unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after.lines().count(), 2, "planned/dry-run fact must NOT be appended");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn parse_facts_content_accepts_array_and_jsonl() {
+        let array = r#"[{"urn":"u1","provider":"google","service":"s","resource_type":"project","verb":"ensure","stack":"x","outcome":"changed","execution_id":1,"desired":{}}]"#;
+        assert_eq!(parse_facts_content(array).unwrap().len(), 1);
+        let jsonl = "{\"a\":1}\n\n{\"b\":2}\n";
+        assert_eq!(parse_facts_content(jsonl).unwrap().len(), 2, "JSONL: blank lines skipped");
+    }
 }


### PR DESCRIPTION
Exposes the noetl-tools **3.26.0** provider surface (wrong-target guard +
`organizations.get` + the 403-may-not-exist / Service-Usage-LRO-poll apply-path
fixes) through the CLI, and adds the **EHDB-less git-backed state sink**.

## Guard wiring
`Tool::Provider` gains a `guard` block (`require_org` / `require_org_display_name`
/ `require_billing_account`), threaded through `tools_bridge` + `playbook_runner`
so `noetl exec --runtime local` passes it to the tool.

## Git-backed state sink
- `noetl provider --facts-out <path>` **and** `noetl exec --facts-out <path>`:
  after each successful provider apply (adopt/converge) append the ownership fact
  as one JSONL line (`{provider_fact:…}`); **planned/dry-run outcomes skipped**.
- `load_facts` reads **both** the JSON-array form and JSONL — backward-compatible
  with `--facts-file`.
- billing-account id + IAM member identifiers **masked** in the written fact
  (neither is a credential; kept out of git by policy).
- Round-trip test: append (masked) → JSONL read-back → fold → ownership; proven
  end-to-end on the built binary via both the verbs and `noetl exec`.

## Versions
- **noetl-executor 0.7.0 → 0.8.0** — `Tool::Provider` public surface changed (the
  `guard` field); the manual bump stops `publish-crate` skipping a stale executor.
- **noetl-tools re-pinned 3.25 → 3.26** (published).
- cli version left to semantic-release (feat → 4.17.0 → 4.18.0).

Clean diff — 8 files, no `release.yml`/`CHANGELOG` touched (apt-CI fixes #69/#70
preserved). Refs noetl/ai-meta#189.

**DO NOT MERGE until the human relays the go.**