### PR TITLE
feat(cli): make the embedded DuckDB engine an opt-in feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Build binaries
-        run: cargo build --release --bins
+        # `duckdb-integration` is non-default (it compiles the DuckDB C++
+        # amalgamation).  Distributed binaries keep it: only dev/default
+        # builds and the PyO3 wheel matrix opt out.
+        run: cargo build --release --bins --features duckdb-integration
       - name: Package tarball
         shell: bash
         run: |
@@ -347,7 +350,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Build binaries
-        run: cargo build --release --bins
+        # `duckdb-integration` is non-default (it compiles the DuckDB C++
+        # amalgamation).  Distributed binaries keep it: only dev/default
+        # builds and the PyO3 wheel matrix opt out.
+        run: cargo build --release --bins --features duckdb-integration
       - name: Build deb package (amd64)
         shell: bash
         run: |
@@ -459,7 +465,7 @@ jobs:
             depends_on "rust" => :build
 
             def install
-              system "cargo", "install", "--bins", *std_cargo_args
+              system "cargo", "install", "--bins", "--features", "duckdb-integration", *std_cargo_args
             end
 
             test do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,24 +51,31 @@ name = "ntl"
 path = "src/main.rs"
 
 [features]
-# Enabled by default so every cli build path (cargo install, apt, homebrew)
-# keeps the DuckDB capability.
-default = ["duckdb-integration"]
-# DuckDB integration — passthrough to `noetl-tools/duckdb-integration`.  The cli
-# routes `duckdb` / `ducklake` tool steps through `noetl_tools::tools::DuckdbTool`
-# (via noetl-executor's tools_bridge — see playbook_runner.rs).  noetl-tools
-# >= 3.20.0 gates the DuckDB C++ engine (`libduckdb-sys`) behind this non-default
-# feature (noetl/ai-meta#185); enabling it here keeps cli's noetl-tools DuckDB
-# path REAL after cli re-pins to 3.20.0 (otherwise DuckdbTool becomes a stub
-# that errors at dispatch).
+# Empty by default: a plain `cargo build` must not compile the DuckDB C++
+# amalgamation.  `libduckdb-sys` takes tens of minutes to an hour per target and
+# is the single largest cost in this crate's build; a five-platform wheel matrix
+# (the PyO3 package on PyPI) cannot pay it, and neither should a dev rebuild.
 #
-# In `default` (unlike noetl/worker#183, which keeps it out of default for a fast
-# dev build): the cli already compiles DuckDB via its own `duckdb` dependency
-# below, so this passthrough adds ZERO build cost — the same libduckdb-sys node
-# is shared by feature unification.  Keeping it off default would pay the DuckDB
-# compile anyway AND leave the noetl-tools path a stub — worst of both.
+# Every *distributed* artifact still ships with DuckDB — the release workflow's
+# tarball + deb jobs, the Homebrew formula, and the Dockerfile all pass
+# `--features duckdb-integration` explicitly.  Only the default build is lean.
+default = []
+# DuckDB integration.  Two things at once, which is why they share a feature:
+#
+#  1. `dep:duckdb` — the CLI's own embedded engine, used by `noetl iap`
+#     (workspace/state/sync/drift over a local `state.duckdb`) and by the
+#     `sink: duckdb:` target in playbook_runner.  Without it those paths are
+#     compiled out and report an actionable rebuild hint.
+#  2. `noetl-tools/duckdb-integration` — the registry-side engine behind
+#     `kind: duckdb` / `ducklake` playbook steps, which the CLI reaches through
+#     noetl-executor's tools_bridge.  noetl-tools >= 3.20.0 gates the same
+#     `libduckdb-sys` node behind this feature (noetl/ai-meta#185); with it off
+#     `DuckdbTool` is a stub that errors at dispatch.
+#
+# Both halves resolve to the same `libduckdb-sys` build via feature unification,
+# so enabling the feature costs one C++ compile, not two.
 # REQUIRES noetl-tools >= 3.20.0 (the version that introduced the feature).
-duckdb-integration = ["noetl-tools/duckdb-integration"]
+duckdb-integration = ["dep:duckdb", "noetl-tools/duckdb-integration"]
 
 [dependencies]
 # Workspace member crate shipping the shared execution core.  R-1.1
@@ -122,7 +129,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sysinfo = "0.31"
 nix = { version = "0.29", features = ["signal", "process"] }
-duckdb = { version = "1.0", features = ["bundled"] }
+# `bundled` compiles DuckDB from the vendored C++ amalgamation, so this is the
+# expensive one.  Optional + non-default; see the `duckdb-integration` feature.
+duckdb = { version = "1.0", features = ["bundled"], optional = true }
 shellexpand = "3.1"
 regex = "1.10"
 rhai = { version = "1.18", features = ["sync"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this layer is cached as long as Cargo.toml/Cargo.lock don't change
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --features duckdb-integration --recipe-path recipe.json
 
-# Build the application
+# Build the application.  `duckdb-integration` is non-default (it compiles the
+# DuckDB C++ amalgamation); pass it explicitly so the shipped image keeps the
+# `noetl iap` + `sink: duckdb:` capability it had before the feature was gated.
 COPY . .
-RUN cargo build --release --bin noetl
+RUN cargo build --release --bin noetl --features duckdb-integration
 
 # Runtime stage
 FROM alpine:3.22.2 AS runtime

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Both binaries run the same CLI and are interchangeable.
 cargo install --bins noetl
 ```
 
+This builds without the embedded DuckDB engine, which keeps the build to a few
+minutes. The pre-built binaries (Homebrew, APT, the GitHub release tarballs)
+all ship *with* it, so this only affects `cargo install`. To match them:
+
+```bash
+cargo install --bins noetl --features duckdb-integration
+```
+
+That compiles DuckDB from its C++ amalgamation and takes considerably longer.
+Without it, `noetl iap` (whose workspace/state ledger is a local
+`state.duckdb`), the `sink: duckdb:` target, and `kind: duckdb` / `ducklake`
+playbook steps report a rebuild hint instead of running.
+
 ### Via Homebrew (macOS)
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3028,8 +3028,21 @@ async fn dispatch(cli: Cli) -> Result<()> {
         }) => {
             cleanup_stuck_executions(&client, &base_url, use_gateway_proxy, older_than_minutes, dry_run, json).await?;
         }
+        // `noetl iap` keeps its workspace/state/sync/drift ledger in a local
+        // `state.duckdb`, so the whole family needs the embedded engine.  The
+        // subcommand stays in `--help` either way — `--help` output is
+        // identical across features — and reports a rebuild hint when the
+        // engine was compiled out.
+        #[cfg(feature = "duckdb-integration")]
         Some(Commands::Iap { command }) => {
             handle_iap_command(command).await?;
+        }
+        #[cfg(not(feature = "duckdb-integration"))]
+        Some(Commands::Iap { .. }) => {
+            bail!(
+                "`noetl iap` needs the embedded DuckDB engine, which this build was compiled \
+                 without.\n  Rebuild with: cargo install noetl --features duckdb-integration"
+            );
         }
         None => {
             println!("Use --help for usage information or --interactive for TUI mode");
@@ -7139,6 +7152,7 @@ fn update_deployment_image(file_path: &str, image: &str) -> Result<()> {
 // Infrastructure as Playbook (IaP) Command Handlers
 // =============================================================================
 
+#[cfg(feature = "duckdb-integration")]
 async fn handle_iap_command(command: IapCommand) -> Result<()> {
     match command {
         IapCommand::Init {
@@ -7167,6 +7181,7 @@ async fn handle_iap_command(command: IapCommand) -> Result<()> {
     }
 }
 
+#[cfg(feature = "duckdb-integration")]
 async fn handle_iap_state_command(command: IapStateCommand) -> Result<()> {
     match command {
         IapStateCommand::List { resource_type, format } => iap_state_list(resource_type.as_deref(), &format).await,
@@ -7176,6 +7191,7 @@ async fn handle_iap_state_command(command: IapStateCommand) -> Result<()> {
     }
 }
 
+#[cfg(feature = "duckdb-integration")]
 async fn handle_iap_sync_command(command: IapSyncCommand) -> Result<()> {
     match command {
         IapSyncCommand::Push { force } => iap_sync_push(force).await,
@@ -7184,6 +7200,7 @@ async fn handle_iap_sync_command(command: IapSyncCommand) -> Result<()> {
     }
 }
 
+#[cfg(feature = "duckdb-integration")]
 async fn handle_iap_drift_command(command: IapDriftCommand) -> Result<()> {
     match command {
         IapDriftCommand::Detect {
@@ -7194,6 +7211,7 @@ async fn handle_iap_drift_command(command: IapDriftCommand) -> Result<()> {
     }
 }
 
+#[cfg(feature = "duckdb-integration")]
 async fn handle_iap_workspace_command(command: IapWorkspaceCommand) -> Result<()> {
     match command {
         IapWorkspaceCommand::List { remote } => iap_workspace_list(remote).await,
@@ -7207,6 +7225,7 @@ async fn handle_iap_workspace_command(command: IapWorkspaceCommand) -> Result<()
 }
 
 /// Initialize IaP state database and configuration
+#[cfg(feature = "duckdb-integration")]
 async fn iap_init(
     project: &str,
     bucket: Option<&str>,
@@ -7358,6 +7377,7 @@ async fn iap_init(
 }
 
 /// Plan infrastructure changes (dry-run)
+#[cfg(feature = "duckdb-integration")]
 async fn iap_plan(playbook: &PathBuf, variables: &[String], verbose: bool) -> Result<()> {
     println!("Planning infrastructure changes...");
     println!("  Playbook: {}", playbook.display());
@@ -7391,6 +7411,7 @@ async fn iap_plan(playbook: &PathBuf, variables: &[String], verbose: bool) -> Re
 }
 
 /// Apply infrastructure changes
+#[cfg(feature = "duckdb-integration")]
 async fn iap_apply(playbook: &PathBuf, variables: &[String], auto_approve: bool, verbose: bool) -> Result<()> {
     if !auto_approve {
         println!("This will apply infrastructure changes.");
@@ -7427,11 +7448,13 @@ async fn iap_apply(playbook: &PathBuf, variables: &[String], auto_approve: bool,
 // =============================================================================
 
 /// Get workspace registry path
+#[cfg(feature = "duckdb-integration")]
 fn get_workspace_registry_path() -> PathBuf {
     PathBuf::from(".noetl/workspaces.json")
 }
 
 /// Workspace registry entry
+#[cfg(feature = "duckdb-integration")]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct WorkspaceEntry {
     name: String,
@@ -7446,6 +7469,7 @@ struct WorkspaceEntry {
 }
 
 /// Load workspace registry
+#[cfg(feature = "duckdb-integration")]
 fn load_workspace_registry() -> Result<HashMap<String, WorkspaceEntry>> {
     let registry_path = get_workspace_registry_path();
     if registry_path.exists() {
@@ -7457,6 +7481,7 @@ fn load_workspace_registry() -> Result<HashMap<String, WorkspaceEntry>> {
 }
 
 /// Save workspace registry
+#[cfg(feature = "duckdb-integration")]
 fn save_workspace_registry(registry: &HashMap<String, WorkspaceEntry>) -> Result<()> {
     let registry_path = get_workspace_registry_path();
     if let Some(parent) = registry_path.parent() {
@@ -7468,6 +7493,7 @@ fn save_workspace_registry(registry: &HashMap<String, WorkspaceEntry>) -> Result
 }
 
 /// List workspaces
+#[cfg(feature = "duckdb-integration")]
 async fn iap_workspace_list(include_remote: bool) -> Result<()> {
     use duckdb::Connection;
 
@@ -7572,6 +7598,7 @@ async fn iap_workspace_list(include_remote: bool) -> Result<()> {
 }
 
 /// Switch to a different workspace
+#[cfg(feature = "duckdb-integration")]
 async fn iap_workspace_switch(name: &str, pull_after: bool) -> Result<()> {
     use duckdb::{params, Connection};
 
@@ -7705,6 +7732,7 @@ async fn iap_workspace_switch(name: &str, pull_after: bool) -> Result<()> {
 }
 
 /// Show current workspace info
+#[cfg(feature = "duckdb-integration")]
 async fn iap_workspace_current() -> Result<()> {
     use duckdb::Connection;
 
@@ -7771,6 +7799,7 @@ async fn iap_workspace_current() -> Result<()> {
 }
 
 /// Create a new workspace
+#[cfg(feature = "duckdb-integration")]
 async fn iap_workspace_create(name: &str, from: Option<&str>, switch_to: bool) -> Result<()> {
     use duckdb::Connection;
 
@@ -7873,6 +7902,7 @@ async fn iap_workspace_create(name: &str, from: Option<&str>, switch_to: bool) -
 }
 
 /// Delete a workspace from registry
+#[cfg(feature = "duckdb-integration")]
 async fn iap_workspace_delete(name: &str, delete_remote: bool, force: bool) -> Result<()> {
     use duckdb::Connection;
     use std::io::{self, Write};
@@ -7956,6 +7986,7 @@ async fn iap_workspace_delete(name: &str, delete_remote: bool, force: bool) -> R
 }
 
 /// List resources in state
+#[cfg(feature = "duckdb-integration")]
 async fn iap_state_list(resource_type: Option<&str>, format: &str) -> Result<()> {
     use duckdb::Connection;
 
@@ -8024,6 +8055,7 @@ async fn iap_state_list(resource_type: Option<&str>, format: &str) -> Result<()>
 }
 
 /// Show details for a specific resource
+#[cfg(feature = "duckdb-integration")]
 async fn iap_state_show(resource: &str) -> Result<()> {
     use duckdb::Connection;
 
@@ -8068,6 +8100,7 @@ async fn iap_state_show(resource: &str) -> Result<()> {
 }
 
 /// Remove a resource from state
+#[cfg(feature = "duckdb-integration")]
 async fn iap_state_rm(resource: &str, force: bool) -> Result<()> {
     use duckdb::Connection;
 
@@ -8106,6 +8139,7 @@ async fn iap_state_rm(resource: &str, force: bool) -> Result<()> {
 }
 
 /// Execute raw SQL query against state database
+#[cfg(feature = "duckdb-integration")]
 async fn iap_state_query(sql: &str) -> Result<()> {
     use std::process::Command;
 
@@ -8135,6 +8169,7 @@ async fn iap_state_query(sql: &str) -> Result<()> {
 }
 
 /// Push local state to GCS
+#[cfg(feature = "duckdb-integration")]
 async fn iap_sync_push(force: bool) -> Result<()> {
     use duckdb::Connection;
 
@@ -8201,6 +8236,7 @@ async fn iap_sync_push(force: bool) -> Result<()> {
 }
 
 /// Pull state from GCS to local
+#[cfg(feature = "duckdb-integration")]
 async fn iap_sync_pull(force: bool) -> Result<()> {
     use duckdb::Connection;
 
@@ -8273,6 +8309,7 @@ async fn iap_sync_pull(force: bool) -> Result<()> {
 }
 
 /// Show sync status
+#[cfg(feature = "duckdb-integration")]
 async fn iap_sync_status() -> Result<()> {
     use duckdb::Connection;
 
@@ -8347,6 +8384,7 @@ async fn iap_sync_status() -> Result<()> {
 }
 
 /// Detect drift between state and actual resources
+#[cfg(feature = "duckdb-integration")]
 async fn iap_drift_detect(_resource_type: Option<&str>, _resource: Option<&str>) -> Result<()> {
     println!("Drift detection requires cloud API access.");
     println!("This feature is not yet implemented.");
@@ -8358,6 +8396,7 @@ async fn iap_drift_detect(_resource_type: Option<&str>, _resource: Option<&str>)
 }
 
 /// Show drift report
+#[cfg(feature = "duckdb-integration")]
 async fn iap_drift_report(format: &str) -> Result<()> {
     use duckdb::Connection;
 
@@ -8415,6 +8454,7 @@ async fn iap_drift_report(format: &str) -> Result<()> {
 }
 
 /// Parse key=value variables
+#[cfg(feature = "duckdb-integration")]
 fn parse_variables(variables: &[String]) -> Result<std::collections::HashMap<String, String>> {
     let mut vars = std::collections::HashMap::new();
     for var in variables {
@@ -8428,6 +8468,7 @@ fn parse_variables(variables: &[String]) -> Result<std::collections::HashMap<Str
 }
 
 /// Get the default state database path
+#[cfg(feature = "duckdb-integration")]
 fn get_state_db_path() -> Result<PathBuf> {
     let path = PathBuf::from(".noetl/state.duckdb");
     Ok(path)

--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+#[cfg(feature = "duckdb-integration")]
 use duckdb::{params, Connection};
 // `Deserialize` / `Serialize` derive macros come in through the
 // `pub use noetl_executor::playbook::*` block below; no direct use
@@ -1406,6 +1407,7 @@ impl PlaybookRunner {
     // in the Tool::Sink arm now goes through `format_sink_payload`.
 
     /// Sink data to DuckDB table
+    #[cfg(feature = "duckdb-integration")]
     fn sink_to_duckdb(&self, db_path: &PathBuf, table: &str, json_data: &str) -> Result<()> {
         // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
@@ -1451,6 +1453,19 @@ impl PlaybookRunner {
                 Ok(())
             }
         }
+    }
+
+    /// `sink: duckdb:` in a playbook, in a build compiled without the embedded
+    /// engine.  The step fails with a rebuild hint rather than the target being
+    /// silently absent from the playbook surface.
+    #[cfg(not(feature = "duckdb-integration"))]
+    fn sink_to_duckdb(&self, db_path: &PathBuf, table: &str, _json_data: &str) -> Result<()> {
+        anyhow::bail!(
+            "sink to DuckDB ({} -> {}) needs the embedded DuckDB engine, which this build \
+             was compiled without.\n  Rebuild with: cargo install noetl --features duckdb-integration",
+            db_path.display(),
+            table
+        )
     }
 
     fn render_template(&self, template: &str, context: &ExecutionContext) -> Result<String> {


### PR DESCRIPTION
## The problem

`Cargo.toml` had `duckdb = { version = "1.0", features = ["bundled"] }` as an
**unconditional** dependency. The `duckdb-integration` feature existed, but it
only forwarded to `noetl-tools` — turning it off changed nothing, because
`libduckdb-sys` still came in through the direct dependency. So *every* build
of this crate compiled the DuckDB C++ amalgamation.

That's tolerable for a binary released a few times a month. It is not tolerable
for the PyO3 wheel matrix (five platforms per release, see
https://github.com/noetl/ai-meta/issues/201), and it was never a good deal for a
dev rebuild.

## The change

- `duckdb` -> `optional = true`
- `duckdb-integration = ["dep:duckdb", "noetl-tools/duckdb-integration"]`
- `default = []`

Both halves of the feature unify on the same `libduckdb-sys` node, so enabling
it costs one C++ compile, not two.

**Compiled out by default** (28 `#[cfg]` attributes, no other code movement):

| Surface | Behaviour without the feature |
|---|---|
| `noetl iap` — 13 leaf commands, 5 dispatch helpers, 10 helpers; ledger is a local `state.duckdb` | dispatch arm bails with a rebuild hint |
| `PlaybookRunner::sink_to_duckdb`, behind `sink: duckdb:` | stub bails with a rebuild hint |
| `kind: duckdb` / `ducklake` steps | already had noetl-tools' own stub message |

The `iap` subcommand stays in the command tree either way, so **`--help` output
is byte-identical across features** — the capability is discoverable and the
error explains itself, rather than the command silently disappearing.

## Distributed artifacts are unchanged

Every artifact users actually install still ships with DuckDB, by passing the
feature explicitly:

- `release.yml` tarball job (linux x86_64/aarch64, darwin arm64)
- `release.yml` deb job
- the generated Homebrew formula's `cargo install`
- `Dockerfile` — **both** the `cargo chef cook` dependency layer and the final
  build, or the cached layer would miss and rebuild everything anyway

Only default/dev builds and the PyO3 wheel opt out. `README.md` documents the
`cargo install` difference and what stops working without it.

## Verification

**The point of the PR** — `libduckdb-sys` is not in the default graph at all:

```
$ cargo tree -i libduckdb-sys
error: package ID specification `libduckdb-sys` did not match any packages

$ cargo tree -i libduckdb-sys --features duckdb-integration
libduckdb-sys v1.2.2
└── duckdb v1.2.2
    ├── noetl v4.19.0
    └── noetl-tools v3.26.0
        ├── noetl v4.19.0
        └── noetl-executor v0.8.0
            └── noetl v4.19.0
```

- Both feature settings `cargo check --all-targets` clean, with the same single
  pre-existing dead-code warning as `main`. `cargo test`: 61 passed.
- All 24 subcommand `--help` outputs byte-identical across features **and**
  against 4.20.0.
- **Default build:** `noetl iap state list` -> rebuild hint, exit 1. A
  `kind: duckdb` step -> noetl-tools' stub message. A local shell playbook run
  is unaffected (`status: ok`).
- **`--features duckdb-integration`:** a `kind: duckdb` playbook creates a table
  and reads `42` back through the real engine; `noetl iap state list` reaches
  the engine and fails only on the absent `.noetl/state.duckdb`, exactly as it
  did before.
- `sink: duckdb:` is compile-verified in both configurations; I did not build a
  runtime fixture for it.

`cargo fmt` was not run (this repo's committed tree doesn't match local rustfmt
1.91.1 output — formatting would reflow hundreds of untouched lines). New lines
are within `max_width = 120`.

Refs https://github.com/noetl/ai-meta/issues/201