### PR TITLE
fix(cli): gate the per-step progress banner on --quiet

### DIFF
--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -303,7 +303,7 @@ impl PlaybookRunner {
                 .unwrap_or_else(|| "start".to_string())
         };
 
-        if self.target.is_some() {
+        if self.target.is_some() && !self.quiet {
             eprintln!("🎯 Target: {}", starting_step);
         }
 
@@ -416,9 +416,15 @@ impl PlaybookRunner {
             }
         }
 
-        eprintln!("\n🔹 Step: {}", step_name);
-        if let Some(desc) = &step.desc {
-            eprintln!("   Description: {}", desc);
+        // Progress lines go to stderr so stdout stays clean for `--json`, but
+        // `--quiet` (which `noetl.run()` from the Python wheel sets) means the
+        // caller took the outcome as a value and wants stderr silent too.  The
+        // per-step banner has to honour that like every other progress print.
+        if !self.quiet {
+            eprintln!("\n🔹 Step: {}", step_name);
+            if let Some(desc) = &step.desc {
+                eprintln!("   Description: {}", desc);
+            }
         }
 
         // DSL v2: Process step.input and merge into context as input.* variables


### PR DESCRIPTION
## The leak

`PlaybookRunner` sends progress to stderr and gates it on `!self.quiet`
throughout — the playbook header, target line, case/route evaluation, tool
detail, completion banner. Three prints slipped through:

- `src/playbook_runner.rs:419` — the `🔹 Step:` banner (ungated)
- `:421` — its `Description:` line (ungated)
- `:307` — the `🎯 Target:` line (gated only on `target.is_some()`)

So a caller that sets `quiet` to consume the outcome as *data* still got
stderr noise:

- `noetl run --json` (which implies quiet) leaked a `🔹 Step:` banner per step.
- The Python wheel's `noetl.run()` sets `quiet=true` and still printed step
  banners — the issue I flagged on noetl/noetl#692.

## The fix

Gate all three on `!self.quiet`, matching every other progress print. A normal
`noetl run` has `quiet=false`, so the interactive banner is unchanged.

## Verification

```
$ noetl run process_order.yaml --runtime local --json 2>stderr.txt
# stderr.txt: only "runtime: local (--runtime flag)" — the CLI's provenance
# echo, which lives in the argv handler (lib.rs), NOT the runner, and is not
# in the noetl.run() path. Zero runner output.

$ noetl run process_order.yaml --runtime local 2>stderr.txt
# stderr.txt: 2 "🔹 Step:" banners — unchanged when not quiet.
```

61 tests pass; no new clippy warnings; new lines within `max_width = 120`.
`cargo fmt` not run (repo tree predates local rustfmt; formatting reflows
untouched lines).

This ships a patch release; the wheel picks it up on its next crate re-pin.