### PR TITLE
fix(provider): surface the fold-coverage warning in the command's own output

### DIFF
--- a/src/provider_cli.rs
+++ b/src/provider_cli.rs
@@ -571,7 +571,7 @@ async fn load_facts(client: &Client, common: &ProviderCommonArgs) -> Result<Vec<
             .with_context(|| format!("parsing facts file {}", path.display()))?;
         // Accept raw tier records (payload-string), decoded bodies, or bare
         // provider_facts — the tier extractor handles all three.
-        return Ok(provider_state::extract_facts_from_tier_records(&records));
+        return Ok(extract_and_report_coverage(&records, &format!("{}", path.display())));
     }
     if let Some(server) = &common.server {
         let mut url = format!("{}/api/ehdb/tiers/eventlog?limit=1000", server.trim_end_matches('/'));
@@ -595,10 +595,41 @@ async fn load_facts(client: &Client, common: &ProviderCommonArgs) -> Result<Vec<
             .and_then(|r| r.get("records"))
             .and_then(|r| r.as_array())
             .unwrap_or(&empty);
-        return Ok(provider_state::extract_facts_from_tier_records(records));
+        return Ok(extract_and_report_coverage(records, &url));
     }
     // No state source → empty model (everything untracked / import).
     Ok(Vec::new())
+}
+
+/// Extract provider facts and **say so on stderr** when the fold understood
+/// nothing.
+///
+/// noetl/ai-meta#191's dangerous half is that an empty ownership model is a
+/// legitimate state, so a caller cannot tell "nothing is tracked yet" from "the
+/// extractor did not understand the data". noetl-tools now warns via `tracing`,
+/// but this binary installs a subscriber **only for the `subscribe` subcommand**
+/// (`src/subscribe/mod.rs`), so on the provider path that warning is emitted into
+/// a void. The signal has to land in this command's own output or it does not
+/// exist for the operator running it.
+///
+/// stderr, not stdout: `provider report --json` output must stay machine-parseable.
+fn extract_and_report_coverage(
+    records: &[serde_json::Value],
+    source: &str,
+) -> Vec<provider_state::ProviderFact> {
+    let (facts, coverage) = provider_state::extract_facts_from_tier_records_with_coverage(records);
+    if coverage.is_suspicious() {
+        eprintln!(
+            "warning: read {} record(s) from {source} and recognised none of them as \
+             provider facts.\n         \
+             This is a parse failure, not an empty ownership model — treating it as \
+             \"nothing is tracked\"\n         \
+             would make an adopt or a destroy plan against a world it cannot see. \
+             (noetl/ai-meta#191)",
+            coverage.considered
+        );
+    }
+    facts
 }
 
 /// Choose the adopt target: the named step, or the sole provider step.


### PR DESCRIPTION
**Held** until noetl-tools ≥ 3.26.2 is published ([tools#93](https://github.com/noetl/tools/pull/93)). Do not merge before then — it will not compile.

## Why this is needed at all

tools#93 makes noetl-tools warn via `tracing` when the `provider_state` fold understands none of the records it was handed (noetl/ai-meta#191). **On this binary that warning goes nowhere.**

`tracing_subscriber` is installed in exactly one place — `src/subscribe/mod.rs`, for the `subscribe` subcommand. The `provider` path never initialises one. So a library-level `tracing::warn!` is emitted into a void, and an operator running `noetl provider report --server …` against data the extractor cannot parse would see precisely what they saw before: nothing.

That is the third layer of the same defect. #191's original bug was an extractor written against an assumed shape; the first fix put the warning behind a function with no production caller; and the warning that *is* reachable has no subscriber on the path that needs it. Each layer passed its own test.

## The change

`load_facts` uses the coverage variant on **both** branches (`--facts-file` and `--server`) and prints to **stderr** when the fold is suspicious — stderr, not stdout, so `provider report --json` stays machine-parseable.

The message states what the condition *means* rather than reporting a count:

```
warning: read 412 record(s) from <source> and recognised none of them as provider facts.
         This is a parse failure, not an empty ownership model — treating it as "nothing is tracked"
         would make an adopt or a destroy plan against a world it cannot see. (noetl/ai-meta#191)
```

An empty ownership model is a **legitimate value**, which is exactly why a count alone would get skimmed past.

## Verification

Compiles against the tools branch via a local `[patch.crates-io]` (**not committed**). The only pre-existing warning is the unrelated dead `extract_auth0_tenant_from_domain`, present on main too.

No manifest change: `noetl-tools = "3.26"` already admits 3.26.2.

Refs noetl/ai-meta#191