### PR TITLE
fix(cli): stop recommending the deprecated exec verb in user-facing hints

### DIFF
--- a/src/playbook_runner.rs
+++ b/src/playbook_runner.rs
@@ -86,11 +86,11 @@ pub struct PlaybookRunner {
     /// When true, after `run()` completes the runner serialises a
     /// `RunOutcome` to stdout as JSON. Combined with `quiet=true` this
     /// gives a pipeline-friendly invocation:
-    ///     noetl exec --runtime local foo.yaml --json
+    ///     noetl run --runtime local foo.yaml --json
     /// → progress on stderr (or nothing in --quiet), structured JSON
     /// envelope on stdout.
     emit_json: bool,
-    /// Git-backed state sink (`noetl exec --facts-out <path>`): after each
+    /// Git-backed state sink (`noetl run --facts-out <path>`): after each
     /// successful provider-step apply, the emitted `provider_fact` is appended
     /// as JSONL (sensitive identifiers masked).  `None` disables persistence.
     facts_out: Option<PathBuf>,
@@ -176,7 +176,7 @@ impl PlaybookRunner {
                 ValidationError::IncompatibleProfile { required } => {
                     anyhow::bail!(
                         "Playbook '{}' requires {} runtime (executor.profile: {})\n\
-                         Use: noetl exec {} --runtime {}",
+                         Use: noetl run {} --runtime {}",
                         playbook.metadata.name,
                         required,
                         required,
@@ -188,7 +188,7 @@ impl PlaybookRunner {
                     anyhow::bail!(
                         "Playbook '{}' requires tool '{}' which is not supported by local runtime.\n\
                          Supported tools: {:?}\n\
-                         Consider using: noetl exec {} --runtime distributed",
+                         Consider using: noetl run {} --runtime distributed",
                         playbook.metadata.name,
                         tool,
                         supported,
@@ -199,7 +199,7 @@ impl PlaybookRunner {
                     anyhow::bail!(
                         "Playbook '{}' requires feature '{}' which is not supported by local runtime.\n\
                          Supported features: {:?}\n\
-                         Consider using: noetl exec {} --runtime distributed",
+                         Consider using: noetl run {} --runtime distributed",
                         playbook.metadata.name,
                         feature,
                         supported,

--- a/src/provider_cli.rs
+++ b/src/provider_cli.rs
@@ -490,7 +490,7 @@ fn mask_fact_identifiers(fact: &serde_json::Value) -> serde_json::Value {
 
 /// Append the applied `provider_fact` from a tool result to the JSONL sink, iff
 /// the outcome is an applied one (`planned` / dry-run is intent-only and is
-/// skipped).  Shared by the provider verbs and `noetl exec --facts-out` so both
+/// skipped).  Shared by the provider verbs and `noetl run --facts-out` so both
 /// dispatch paths persist ownership identically.
 pub(crate) fn append_applied_fact(out: &Path, data: &serde_json::Value) -> Result<()> {
     let Some(fact) = data.get("provider_fact") else {

--- a/src/subscribe/dispatch.rs
+++ b/src/subscribe/dispatch.rs
@@ -7,7 +7,7 @@
 //!
 //! So the default — the "pure local" mode the phase is about — runs the target
 //! playbook **in-process** with the message as its workload, via the same
-//! [`crate::playbook_runner::PlaybookRunner`] `noetl exec --runtime local`
+//! [`crate::playbook_runner::PlaybookRunner`] `noetl run --runtime local`
 //! uses.  No server, no NATS-dispatch.  The `--dispatch server` variant (or a
 //! `--server-url`) instead POSTs `/api/execute` to a control plane, keeping
 //! the event model identical — only the dispatch sink differs.


### PR DESCRIPTION
Found while sweeping the tail of `noetl/ai-meta#193`.

4.19.0 made `run` the playbook verb and left `exec`/`execute` as deprecated aliases that nudge on stderr. Three hints the CLI prints when the runtime looks wrong still told the user to run the deprecated form:

```
Use: noetl exec {} --runtime {}
Consider using: noetl exec {} --runtime distributed     (x2)
```

So the tool recommended a command that then warns about itself. Those three, plus four doc comments, now say `noetl run`.

## What was deliberately not touched

`src/lib.rs` documents `noetl execute playbook|rerun|status` — a **different command group**, not the deprecated run alias. #193 calls this out explicitly. The regex requires `exec` not be followed by a letter, so `execute` and `execution` are untouched; those doc comments are byte-identical after this change.

This mattered more than it sounds: a plain substring grep for `noetl exec` matches `noetl execute` and `noetl execution` too, and in a sibling repo it flagged a `kubectl --context $ctx -n noetl exec deploy/…` line — a kubectl invocation that only matches because the namespace is called `noetl`. A naive sweep would have corrupted it.

## Verification

- bare `noetl exec` in `src/`: **0** after (was 7)
- `noetl execute <group>` doc comments: unchanged
- no test asserts on the old strings (`grep` over `tests/` is empty)
- no `Cargo.toml` change — semantic-release owns the version

Typed `fix` rather than `docs` on purpose: a `docs` subject produces no release, and printed output only changes for users once a release ships.

Refs noetl/ai-meta#193